### PR TITLE
feat(leave-balances): Módulo de Saldos Laborales

### DIFF
--- a/backend/alembic/versions/add_leave_balances.py
+++ b/backend/alembic/versions/add_leave_balances.py
@@ -1,0 +1,139 @@
+"""Add leave balances tables for time-off management
+
+Revision ID: c3d4e5f6g7h8
+Revises: b2c3d4e5f6g7
+Create Date: 2025-01-15
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = 'c3d4e5f6g7h8'
+down_revision = 'b2c3d4e5f6g7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create leave_unit enum
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE leaveunit AS ENUM ('days', 'hours');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    """)
+
+    # Create accrual_type enum
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE accrualtype AS ENUM ('annual', 'fixed', 'overtime', 'manual');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    """)
+
+    # Create transaction_type enum
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE transactiontype AS ENUM ('credit', 'debit', 'adjustment', 'expiration');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    """)
+
+    # Create leave_policies table
+    op.create_table(
+        'leave_policies',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('code', sa.String(50), nullable=False, unique=True),
+        sa.Column('name', sa.String(100), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('unit', postgresql.ENUM('days', 'hours', name='leaveunit', create_type=False), nullable=False, server_default='days'),
+        sa.Column('accrual_type', postgresql.ENUM('annual', 'fixed', 'overtime', 'manual', name='accrualtype', create_type=False), nullable=False, server_default='annual'),
+        sa.Column('base_amount', sa.Numeric(10, 2), nullable=False, server_default='0'),
+        sa.Column('increment_per_years', sa.Numeric(10, 2), nullable=False, server_default='0'),
+        sa.Column('years_for_increment', sa.Integer(), nullable=False, server_default='5'),
+        sa.Column('max_amount', sa.Numeric(10, 2), nullable=True),
+        sa.Column('expires_after_days', sa.Integer(), nullable=True),
+        sa.Column('allow_carryover', sa.Boolean(), nullable=False, server_default='false'),
+        sa.Column('max_carryover', sa.Numeric(10, 2), nullable=True),
+        sa.Column('color', sa.String(7), nullable=False, server_default='#3b82f6'),
+        sa.Column('is_active', sa.Boolean(), nullable=False, server_default='true'),
+        sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+
+    # Create leave_balances table
+    op.create_table(
+        'leave_balances',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('employee_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('employees.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('policy_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('leave_policies.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('period_year', sa.Integer(), nullable=False),
+        sa.Column('period_start', sa.Date(), nullable=False),
+        sa.Column('period_end', sa.Date(), nullable=False),
+        sa.Column('initial_balance', sa.Numeric(10, 2), nullable=False, server_default='0'),
+        sa.Column('current_balance', sa.Numeric(10, 2), nullable=False, server_default='0'),
+        sa.Column('used_amount', sa.Numeric(10, 2), nullable=False, server_default='0'),
+        sa.Column('pending_amount', sa.Numeric(10, 2), nullable=False, server_default='0'),
+        sa.Column('carryover_amount', sa.Numeric(10, 2), nullable=False, server_default='0'),
+        sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column('updated_at', sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.UniqueConstraint('employee_id', 'policy_id', 'period_year', name='uq_employee_policy_period'),
+        sa.CheckConstraint('current_balance >= 0', name='ck_positive_balance'),
+    )
+
+    # Create leave_transactions table
+    op.create_table(
+        'leave_transactions',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column('balance_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('leave_balances.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('transaction_type', postgresql.ENUM('credit', 'debit', 'adjustment', 'expiration', name='transactiontype', create_type=False), nullable=False),
+        sa.Column('amount', sa.Numeric(10, 2), nullable=False),
+        sa.Column('balance_before', sa.Numeric(10, 2), nullable=False),
+        sa.Column('balance_after', sa.Numeric(10, 2), nullable=False),
+        sa.Column('schedule_exception_id', postgresql.UUID(as_uuid=True), sa.ForeignKey('schedule_exceptions.id', ondelete='SET NULL'), nullable=True),
+        sa.Column('usage_start_date', sa.Date(), nullable=True),
+        sa.Column('usage_end_date', sa.Date(), nullable=True),
+        sa.Column('description', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column('created_by', postgresql.UUID(as_uuid=True), sa.ForeignKey('users.id', ondelete='SET NULL'), nullable=True),
+    )
+
+    # Create indexes
+    op.create_index('ix_leave_policies_code', 'leave_policies', ['code'])
+    op.create_index('ix_leave_balances_employee', 'leave_balances', ['employee_id'])
+    op.create_index('ix_leave_balances_policy', 'leave_balances', ['policy_id'])
+    op.create_index('ix_leave_balances_period', 'leave_balances', ['period_year'])
+    op.create_index('ix_leave_transactions_balance', 'leave_transactions', ['balance_id'])
+    op.create_index('ix_leave_transactions_created', 'leave_transactions', ['created_at'])
+
+    # Insert default policies
+    op.execute("""
+        INSERT INTO leave_policies (id, code, name, description, unit, accrual_type, base_amount, increment_per_years, years_for_increment, max_amount, color)
+        VALUES
+            (gen_random_uuid(), 'VACATION', 'Vacaciones', 'Dias de vacaciones anuales segun antiguedad', 'days', 'annual', 15, 1, 5, 30, '#1E3A5F'),
+            (gen_random_uuid(), 'SICK_LEAVE', 'Incapacidad', 'Fondo de dias por enfermedad', 'days', 'fixed', 30, 0, 1, NULL, '#DC2626'),
+            (gen_random_uuid(), 'COMPENSATORY', 'Horas Compensatorias', 'Acumulacion por horas extra trabajadas', 'hours', 'overtime', 0, 0, 1, NULL, '#059669');
+    """)
+
+
+def downgrade() -> None:
+    # Drop indexes
+    op.drop_index('ix_leave_transactions_created')
+    op.drop_index('ix_leave_transactions_balance')
+    op.drop_index('ix_leave_balances_period')
+    op.drop_index('ix_leave_balances_policy')
+    op.drop_index('ix_leave_balances_employee')
+    op.drop_index('ix_leave_policies_code')
+
+    # Drop tables
+    op.drop_table('leave_transactions')
+    op.drop_table('leave_balances')
+    op.drop_table('leave_policies')
+
+    # Drop enum types
+    op.execute('DROP TYPE IF EXISTS transactiontype')
+    op.execute('DROP TYPE IF EXISTS accrualtype')
+    op.execute('DROP TYPE IF EXISTS leaveunit')

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -61,3 +61,11 @@ async def get_current_active_admin(
             detail="Not enough permissions",
         )
     return current_user
+
+
+# Alias for any authenticated active user (no role restriction)
+async def get_current_active_user(
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> User:
+    """Returns the current authenticated active user (any role)."""
+    return current_user

--- a/backend/app/api/v1/endpoints/leave_balances.py
+++ b/backend/app/api/v1/endpoints/leave_balances.py
@@ -171,8 +171,11 @@ async def list_balances(
     emp_query = select(Employee).where(Employee.is_active == True)
 
     if search:
-        search_filter = f"%{search}%"
+        search_term = search.strip()
+        search_filter = f"%{search_term}%"
+        # Buscar por codigo exacto O por nombre/apellido parcial
         emp_query = emp_query.where(
+            (Employee.employee_code == search_term) |
             (Employee.first_name.ilike(search_filter)) |
             (Employee.last_name.ilike(search_filter)) |
             (Employee.employee_code.ilike(search_filter))

--- a/backend/app/api/v1/endpoints/leave_balances.py
+++ b/backend/app/api/v1/endpoints/leave_balances.py
@@ -1,0 +1,524 @@
+"""
+Leave Balances API Endpoints - Saldos Laborales
+"""
+from datetime import date
+from decimal import Decimal
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status, Query
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.api.deps import get_db, get_current_active_admin
+from app.models.user import User
+from app.models.employee import Employee
+from app.models.leave_balance import LeavePolicy, LeaveBalance, LeaveTransaction
+from app.schemas.leave_balance import (
+    LeavePolicyCreate, LeavePolicyUpdate, LeavePolicyResponse,
+    LeaveBalanceCreate, LeaveBalanceUpdate, LeaveBalanceResponse,
+    LeaveTransactionCreate, LeaveTransactionResponse,
+    EmployeeBalanceSummary, EmployeeBalanceDetail,
+    BulkAccrualCreate, BalanceCalculationRequest, BalanceCalculationResponse,
+    LeaveUnitEnum
+)
+from app.services.leave_service import LeaveService
+
+router = APIRouter()
+
+
+# ============ Leave Policies ============
+
+@router.get("/policies", response_model=list[LeavePolicyResponse])
+async def list_policies(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_active_admin)],
+    active_only: bool = True,
+) -> list[LeavePolicyResponse]:
+    """Lista todas las politicas de saldo"""
+    query = select(LeavePolicy)
+    if active_only:
+        query = query.where(LeavePolicy.is_active == True)
+    query = query.order_by(LeavePolicy.name)
+
+    result = await db.execute(query)
+    policies = result.scalars().all()
+
+    return [LeavePolicyResponse.model_validate(p) for p in policies]
+
+
+@router.post("/policies", response_model=LeavePolicyResponse, status_code=status.HTTP_201_CREATED)
+async def create_policy(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_active_admin)],
+    policy_in: LeavePolicyCreate,
+) -> LeavePolicyResponse:
+    """Crea una nueva politica de saldo"""
+    # Verificar codigo unico
+    result = await db.execute(
+        select(LeavePolicy).where(LeavePolicy.code == policy_in.code)
+    )
+    if result.scalar_one_or_none():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Policy code already exists"
+        )
+
+    policy = LeavePolicy(**policy_in.model_dump())
+    db.add(policy)
+    await db.commit()
+    await db.refresh(policy)
+
+    return LeavePolicyResponse.model_validate(policy)
+
+
+@router.get("/policies/{policy_id}", response_model=LeavePolicyResponse)
+async def get_policy(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_active_admin)],
+    policy_id: UUID,
+) -> LeavePolicyResponse:
+    """Obtiene una politica por ID"""
+    result = await db.execute(
+        select(LeavePolicy).where(LeavePolicy.id == policy_id)
+    )
+    policy = result.scalar_one_or_none()
+
+    if not policy:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found"
+        )
+
+    return LeavePolicyResponse.model_validate(policy)
+
+
+@router.patch("/policies/{policy_id}", response_model=LeavePolicyResponse)
+async def update_policy(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_active_admin)],
+    policy_id: UUID,
+    policy_in: LeavePolicyUpdate,
+) -> LeavePolicyResponse:
+    """Actualiza una politica"""
+    result = await db.execute(
+        select(LeavePolicy).where(LeavePolicy.id == policy_id)
+    )
+    policy = result.scalar_one_or_none()
+
+    if not policy:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found"
+        )
+
+    update_data = policy_in.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(policy, field, value)
+
+    await db.commit()
+    await db.refresh(policy)
+
+    return LeavePolicyResponse.model_validate(policy)
+
+
+@router.delete("/policies/{policy_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_policy(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_active_admin)],
+    policy_id: UUID,
+) -> None:
+    """Elimina una politica"""
+    result = await db.execute(
+        select(LeavePolicy).where(LeavePolicy.id == policy_id)
+    )
+    policy = result.scalar_one_or_none()
+
+    if not policy:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found"
+        )
+
+    await db.delete(policy)
+    await db.commit()
+
+
+# ============ Leave Balances ============
+
+@router.get("/", response_model=list[EmployeeBalanceSummary])
+async def list_balances(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_active_admin)],
+    search: str | None = None,
+    policy_id: UUID | None = None,
+    department_id: UUID | None = None,
+    employee_id: UUID | None = None,
+    period_year: int | None = None,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=500),
+) -> list[EmployeeBalanceSummary]:
+    """
+    Lista saldos agrupados por empleado.
+    Vista principal del modulo de saldos.
+    """
+    # Si no se especifica periodo, usar el actual
+    if not period_year:
+        period_year = date.today().year
+
+    # Query base de empleados
+    emp_query = select(Employee).where(Employee.is_active == True)
+
+    if search:
+        search_filter = f"%{search}%"
+        emp_query = emp_query.where(
+            (Employee.first_name.ilike(search_filter)) |
+            (Employee.last_name.ilike(search_filter)) |
+            (Employee.employee_code.ilike(search_filter))
+        )
+
+    if department_id:
+        emp_query = emp_query.where(Employee.department_id == department_id)
+
+    if employee_id:
+        emp_query = emp_query.where(Employee.id == employee_id)
+
+    emp_query = emp_query.order_by(Employee.last_name, Employee.first_name)
+    emp_query = emp_query.offset(skip).limit(limit)
+
+    result = await db.execute(emp_query)
+    employees = result.scalars().all()
+
+    summaries = []
+    for emp in employees:
+        # Obtener saldos del empleado para el periodo
+        bal_query = (
+            select(LeaveBalance)
+            .options(selectinload(LeaveBalance.policy))
+            .where(
+                LeaveBalance.employee_id == emp.id,
+                LeaveBalance.period_year == period_year
+            )
+        )
+
+        if policy_id:
+            bal_query = bal_query.where(LeaveBalance.policy_id == policy_id)
+
+        bal_result = await db.execute(bal_query)
+        balances = bal_result.scalars().all()
+
+        # Obtener nombre del departamento
+        dept_name = None
+        if emp.department_id:
+            from app.models.department import Department
+            dept_result = await db.execute(
+                select(Department.name).where(Department.id == emp.department_id)
+            )
+            dept_name = dept_result.scalar_one_or_none()
+
+        balance_responses = []
+        for bal in balances:
+            balance_responses.append(LeaveBalanceResponse(
+                id=bal.id,
+                employee_id=bal.employee_id,
+                policy_id=bal.policy_id,
+                period_year=bal.period_year,
+                period_start=bal.period_start,
+                period_end=bal.period_end,
+                initial_balance=bal.initial_balance,
+                current_balance=bal.current_balance,
+                used_amount=bal.used_amount,
+                pending_amount=bal.pending_amount,
+                carryover_amount=bal.carryover_amount,
+                available_balance=bal.available_balance,
+                created_at=bal.created_at,
+                updated_at=bal.updated_at,
+                policy_name=bal.policy.name if bal.policy else None,
+                policy_code=bal.policy.code if bal.policy else None,
+                policy_unit=LeaveUnitEnum(bal.policy.unit.value) if bal.policy else None,
+                policy_color=bal.policy.color if bal.policy else None,
+            ))
+
+        summaries.append(EmployeeBalanceSummary(
+            employee_id=emp.id,
+            employee_code=emp.employee_code,
+            first_name=emp.first_name,
+            last_name=emp.last_name,
+            department_name=dept_name,
+            balances=balance_responses
+        ))
+
+    return summaries
+
+
+@router.get("/employee/{employee_id}/detail", response_model=EmployeeBalanceDetail)
+async def get_employee_balance_detail(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_active_admin)],
+    employee_id: UUID,
+    policy_id: UUID,
+    period_year: int | None = None,
+) -> EmployeeBalanceDetail:
+    """
+    Obtiene detalle de un saldo con historial de transacciones.
+    Vista expandida de la tabla.
+    """
+    if not period_year:
+        period_year = date.today().year
+
+    # Obtener empleado
+    emp_result = await db.execute(
+        select(Employee).where(Employee.id == employee_id)
+    )
+    employee = emp_result.scalar_one_or_none()
+
+    if not employee:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Employee not found"
+        )
+
+    # Obtener saldo
+    bal_result = await db.execute(
+        select(LeaveBalance)
+        .options(
+            selectinload(LeaveBalance.policy),
+            selectinload(LeaveBalance.transactions)
+        )
+        .where(
+            LeaveBalance.employee_id == employee_id,
+            LeaveBalance.policy_id == policy_id,
+            LeaveBalance.period_year == period_year
+        )
+    )
+    balance = bal_result.scalar_one_or_none()
+
+    if not balance:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Balance not found for this employee/policy/period"
+        )
+
+    # Obtener nombre del departamento
+    dept_name = None
+    if employee.department_id:
+        from app.models.department import Department
+        dept_result = await db.execute(
+            select(Department.name).where(Department.id == employee.department_id)
+        )
+        dept_name = dept_result.scalar_one_or_none()
+
+    # Calcular antiguedad
+    service = LeaveService(db)
+    years_of_service = await service.calculate_years_of_service(employee)
+
+    # Construir respuesta
+    balance_response = LeaveBalanceResponse(
+        id=balance.id,
+        employee_id=balance.employee_id,
+        policy_id=balance.policy_id,
+        period_year=balance.period_year,
+        period_start=balance.period_start,
+        period_end=balance.period_end,
+        initial_balance=balance.initial_balance,
+        current_balance=balance.current_balance,
+        used_amount=balance.used_amount,
+        pending_amount=balance.pending_amount,
+        carryover_amount=balance.carryover_amount,
+        available_balance=balance.available_balance,
+        created_at=balance.created_at,
+        updated_at=balance.updated_at,
+        policy_name=balance.policy.name if balance.policy else None,
+        policy_code=balance.policy.code if balance.policy else None,
+        policy_unit=LeaveUnitEnum(balance.policy.unit.value) if balance.policy else None,
+        policy_color=balance.policy.color if balance.policy else None,
+    )
+
+    transactions = [
+        LeaveTransactionResponse.model_validate(t)
+        for t in sorted(balance.transactions, key=lambda x: x.created_at, reverse=True)
+    ]
+
+    return EmployeeBalanceDetail(
+        employee_id=employee.id,
+        employee_code=employee.employee_code,
+        first_name=employee.first_name,
+        last_name=employee.last_name,
+        department_name=dept_name,
+        hire_date=employee.hire_date,
+        years_of_service=years_of_service,
+        balance=balance_response,
+        transactions=transactions
+    )
+
+
+@router.post("/", response_model=LeaveBalanceResponse, status_code=status.HTTP_201_CREATED)
+async def create_balance(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_active_admin)],
+    balance_in: LeaveBalanceCreate,
+) -> LeaveBalanceResponse:
+    """Crea un saldo manualmente"""
+    service = LeaveService(db)
+    balance = await service.get_or_create_balance(
+        employee_id=balance_in.employee_id,
+        policy_id=balance_in.policy_id,
+        period_year=balance_in.period_year
+    )
+
+    # Actualizar valores si se especifican
+    if balance_in.initial_balance:
+        balance.initial_balance = balance_in.initial_balance
+        balance.current_balance = balance_in.initial_balance + balance_in.carryover_amount
+    if balance_in.carryover_amount:
+        balance.carryover_amount = balance_in.carryover_amount
+
+    await db.commit()
+    await db.refresh(balance)
+
+    # Cargar relacion de policy
+    pol_result = await db.execute(
+        select(LeavePolicy).where(LeavePolicy.id == balance.policy_id)
+    )
+    policy = pol_result.scalar_one_or_none()
+
+    return LeaveBalanceResponse(
+        id=balance.id,
+        employee_id=balance.employee_id,
+        policy_id=balance.policy_id,
+        period_year=balance.period_year,
+        period_start=balance.period_start,
+        period_end=balance.period_end,
+        initial_balance=balance.initial_balance,
+        current_balance=balance.current_balance,
+        used_amount=balance.used_amount,
+        pending_amount=balance.pending_amount,
+        carryover_amount=balance.carryover_amount,
+        available_balance=balance.available_balance,
+        created_at=balance.created_at,
+        updated_at=balance.updated_at,
+        policy_name=policy.name if policy else None,
+        policy_code=policy.code if policy else None,
+        policy_unit=LeaveUnitEnum(policy.unit.value) if policy else None,
+        policy_color=policy.color if policy else None,
+    )
+
+
+@router.post("/bulk-accrual", response_model=dict)
+async def bulk_accrual(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_active_admin)],
+    accrual_in: BulkAccrualCreate,
+) -> dict:
+    """Acreditacion masiva de saldos para todos los empleados activos"""
+    service = LeaveService(db)
+    count = await service.bulk_accrual(
+        policy_id=accrual_in.policy_id,
+        period_year=accrual_in.period_year,
+        employee_ids=accrual_in.employee_ids
+    )
+
+    return {
+        "message": f"Balances created/updated for {count} employees",
+        "count": count,
+        "policy_id": str(accrual_in.policy_id),
+        "period_year": accrual_in.period_year
+    }
+
+
+@router.post("/calculate", response_model=BalanceCalculationResponse)
+async def calculate_balance(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_active_admin)],
+    calc_in: BalanceCalculationRequest,
+) -> BalanceCalculationResponse:
+    """Calcula el saldo que le corresponde a un empleado segun su antiguedad"""
+    # Obtener empleado
+    emp_result = await db.execute(
+        select(Employee).where(Employee.id == calc_in.employee_id)
+    )
+    employee = emp_result.scalar_one_or_none()
+
+    if not employee:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Employee not found"
+        )
+
+    # Obtener politica
+    pol_result = await db.execute(
+        select(LeavePolicy).where(LeavePolicy.id == calc_in.policy_id)
+    )
+    policy = pol_result.scalar_one_or_none()
+
+    if not policy:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Policy not found"
+        )
+
+    service = LeaveService(db)
+    years_of_service = await service.calculate_years_of_service(
+        employee,
+        date(calc_in.period_year, 1, 1)
+    )
+    base, increment, total = await service.calculate_vacation_days(
+        employee, policy, calc_in.period_year
+    )
+
+    return BalanceCalculationResponse(
+        employee_id=employee.id,
+        policy_id=policy.id,
+        period_year=calc_in.period_year,
+        years_of_service=years_of_service,
+        calculated_amount=total,
+        base_amount=base,
+        increment_amount=increment
+    )
+
+
+# ============ Transactions ============
+
+@router.post("/transactions", response_model=LeaveTransactionResponse, status_code=status.HTTP_201_CREATED)
+async def create_transaction(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_active_admin)],
+    trans_in: LeaveTransactionCreate,
+) -> LeaveTransactionResponse:
+    """Crea una transaccion manual (ajuste, correccion, etc)"""
+    from app.models.leave_balance import TransactionType
+
+    service = LeaveService(db)
+    transaction = await service.create_transaction(
+        balance_id=trans_in.balance_id,
+        transaction_type=TransactionType(trans_in.transaction_type.value),
+        amount=trans_in.amount,
+        description=trans_in.description,
+        schedule_exception_id=trans_in.schedule_exception_id,
+        usage_start_date=trans_in.usage_start_date,
+        usage_end_date=trans_in.usage_end_date,
+        created_by=current_user.id
+    )
+
+    await db.commit()
+    await db.refresh(transaction)
+
+    return LeaveTransactionResponse.model_validate(transaction)
+
+
+@router.get("/transactions/{balance_id}", response_model=list[LeaveTransactionResponse])
+async def list_transactions(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_active_admin)],
+    balance_id: UUID,
+) -> list[LeaveTransactionResponse]:
+    """Lista transacciones de un saldo"""
+    result = await db.execute(
+        select(LeaveTransaction)
+        .where(LeaveTransaction.balance_id == balance_id)
+        .order_by(LeaveTransaction.created_at.desc())
+    )
+    transactions = result.scalars().all()
+
+    return [LeaveTransactionResponse.model_validate(t) for t in transactions]

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,9 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import auth, employees, faces, attendance, settings, positions, departments, locations, schedules
+from app.api.v1.endpoints import (
+    auth, employees, faces, attendance, settings,
+    positions, departments, locations, schedules, leave_balances
+)
 
 api_router = APIRouter()
 
@@ -13,3 +16,4 @@ api_router.include_router(positions.router, prefix="/positions", tags=["position
 api_router.include_router(departments.router, prefix="/departments", tags=["departments"])
 api_router.include_router(locations.router, prefix="/locations", tags=["locations"])
 api_router.include_router(schedules.router, prefix="/schedules", tags=["schedules"])
+api_router.include_router(leave_balances.router, prefix="/leave-balances", tags=["leave-balances"])

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -8,6 +8,10 @@ from app.models.settings import Settings
 from app.models.position import Position
 from app.models.department import Department
 from app.models.location import Location
+from app.models.leave_balance import (
+    LeavePolicy, LeaveBalance, LeaveTransaction,
+    LeaveUnit, AccrualType, TransactionType
+)
 
 __all__ = [
     "User",
@@ -24,4 +28,11 @@ __all__ = [
     "Position",
     "Department",
     "Location",
+    # Leave Balance
+    "LeavePolicy",
+    "LeaveBalance",
+    "LeaveTransaction",
+    "LeaveUnit",
+    "AccrualType",
+    "TransactionType",
 ]

--- a/backend/app/models/leave_balance.py
+++ b/backend/app/models/leave_balance.py
@@ -1,0 +1,237 @@
+"""
+Leave Balance Models - Saldos Laborales
+
+Tipos de saldo:
+- Vacaciones (dias): acumulacion anual segun antiguedad
+- Incapacidad (dias): fondo fijo anual
+- Horas Compensatorias (horas:minutos): por horas extra trabajadas
+- Personalizados: configurables por empresa
+"""
+import uuid
+from datetime import datetime, date
+from decimal import Decimal
+from enum import Enum as PyEnum
+
+from sqlalchemy import (
+    String, Boolean, DateTime, Date, Integer, ForeignKey,
+    Text, Numeric, UniqueConstraint, Enum, CheckConstraint
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class LeaveUnit(str, PyEnum):
+    """Unidad de medida del saldo"""
+    DAYS = "days"           # Dias
+    HOURS = "hours"         # Horas (para compensatorios)
+
+
+class AccrualType(str, PyEnum):
+    """Tipo de acumulacion del saldo"""
+    ANNUAL = "annual"           # Acumulacion anual (vacaciones)
+    FIXED = "fixed"             # Fondo fijo (incapacidad)
+    OVERTIME = "overtime"       # Por horas extra (compensatorio)
+    MANUAL = "manual"           # Asignacion manual
+
+
+class TransactionType(str, PyEnum):
+    """Tipo de transaccion"""
+    CREDIT = "credit"           # Acreditacion (suma)
+    DEBIT = "debit"             # Uso/Descuento (resta)
+    ADJUSTMENT = "adjustment"   # Ajuste manual
+    EXPIRATION = "expiration"   # Vencimiento
+
+
+class LeavePolicy(Base):
+    """
+    Politica de saldo laboral - Define tipos de saldo y reglas de acumulacion.
+
+    Ejemplos:
+    - Vacaciones: 15 dias/anio, acumulacion anual
+    - Incapacidad: 30 dias/anio, fondo fijo
+    - Compensatorio: horas extra trabajadas
+    """
+    __tablename__ = "leave_policies"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    code: Mapped[str] = mapped_column(
+        String(50), unique=True, nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Configuracion
+    unit: Mapped[LeaveUnit] = mapped_column(
+        Enum(LeaveUnit), nullable=False, default=LeaveUnit.DAYS
+    )
+    accrual_type: Mapped[AccrualType] = mapped_column(
+        Enum(AccrualType), nullable=False, default=AccrualType.ANNUAL
+    )
+
+    # Cantidad base por periodo (ej: 15 dias/anio)
+    base_amount: Mapped[Decimal] = mapped_column(
+        Numeric(10, 2), nullable=False, default=0
+    )
+
+    # Incremento por anio de antiguedad (ej: +1 dia por cada 5 anios)
+    increment_per_years: Mapped[Decimal] = mapped_column(
+        Numeric(10, 2), nullable=False, default=0
+    )
+    years_for_increment: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=5
+    )
+    max_amount: Mapped[Decimal | None] = mapped_column(
+        Numeric(10, 2), nullable=True  # Tope maximo
+    )
+
+    # Reglas de expiracion
+    expires_after_days: Mapped[int | None] = mapped_column(
+        Integer, nullable=True  # Dias para vencer (null = no vence)
+    )
+    allow_carryover: Mapped[bool] = mapped_column(
+        Boolean, default=False  # Permite arrastrar al siguiente periodo
+    )
+    max_carryover: Mapped[Decimal | None] = mapped_column(
+        Numeric(10, 2), nullable=True  # Maximo a arrastrar
+    )
+
+    # Color para UI
+    color: Mapped[str] = mapped_column(
+        String(7), default="#3b82f6"  # Hex color
+    )
+
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    # Relationships
+    balances: Mapped[list["LeaveBalance"]] = relationship(
+        "LeaveBalance", back_populates="policy", cascade="all, delete-orphan"
+    )
+
+
+class LeaveBalance(Base):
+    """
+    Saldo de un empleado para un tipo de permiso en un periodo.
+
+    Ej: Juan tiene 15 dias de vacaciones para 2025
+    """
+    __tablename__ = "leave_balances"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    employee_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("employees.id", ondelete="CASCADE"), nullable=False
+    )
+    policy_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("leave_policies.id", ondelete="CASCADE"), nullable=False
+    )
+
+    # Periodo (anual normalmente)
+    period_year: Mapped[int] = mapped_column(Integer, nullable=False)
+    period_start: Mapped[date] = mapped_column(Date, nullable=False)
+    period_end: Mapped[date] = mapped_column(Date, nullable=False)
+
+    # Saldos (en la unidad definida por policy)
+    initial_balance: Mapped[Decimal] = mapped_column(
+        Numeric(10, 2), nullable=False, default=0
+    )
+    current_balance: Mapped[Decimal] = mapped_column(
+        Numeric(10, 2), nullable=False, default=0
+    )
+    used_amount: Mapped[Decimal] = mapped_column(
+        Numeric(10, 2), nullable=False, default=0
+    )
+    pending_amount: Mapped[Decimal] = mapped_column(
+        Numeric(10, 2), nullable=False, default=0  # Solicitudes pendientes
+    )
+
+    # Arrastre del periodo anterior
+    carryover_amount: Mapped[Decimal] = mapped_column(
+        Numeric(10, 2), nullable=False, default=0
+    )
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    # Relationships
+    policy: Mapped["LeavePolicy"] = relationship(
+        "LeavePolicy", back_populates="balances"
+    )
+    transactions: Mapped[list["LeaveTransaction"]] = relationship(
+        "LeaveTransaction", back_populates="balance", cascade="all, delete-orphan"
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "employee_id", "policy_id", "period_year",
+            name="uq_employee_policy_period"
+        ),
+        CheckConstraint("current_balance >= 0", name="ck_positive_balance"),
+    )
+
+    @property
+    def available_balance(self) -> Decimal:
+        """Saldo disponible = actual - pendiente"""
+        return self.current_balance - self.pending_amount
+
+
+class LeaveTransaction(Base):
+    """
+    Transaccion/Movimiento de saldo.
+
+    Registra cada cambio: acreditacion anual, uso por vacaciones, ajustes, etc.
+    """
+    __tablename__ = "leave_transactions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    balance_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("leave_balances.id", ondelete="CASCADE"), nullable=False
+    )
+
+    transaction_type: Mapped[TransactionType] = mapped_column(
+        Enum(TransactionType), nullable=False
+    )
+    amount: Mapped[Decimal] = mapped_column(
+        Numeric(10, 2), nullable=False
+    )
+
+    # Saldo antes y despues de la transaccion
+    balance_before: Mapped[Decimal] = mapped_column(
+        Numeric(10, 2), nullable=False
+    )
+    balance_after: Mapped[Decimal] = mapped_column(
+        Numeric(10, 2), nullable=False
+    )
+
+    # Referencia a la excepcion de horario (si aplica)
+    schedule_exception_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("schedule_exceptions.id", ondelete="SET NULL"), nullable=True
+    )
+
+    # Fechas de uso (para vacaciones, etc.)
+    usage_start_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    usage_end_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+
+    # Relationships
+    balance: Mapped["LeaveBalance"] = relationship(
+        "LeaveBalance", back_populates="transactions"
+    )

--- a/backend/app/models/leave_balance.py
+++ b/backend/app/models/leave_balance.py
@@ -24,24 +24,24 @@ from app.db.base import Base
 
 class LeaveUnit(str, PyEnum):
     """Unidad de medida del saldo"""
-    DAYS = "days"           # Dias
-    HOURS = "hours"         # Horas (para compensatorios)
+    days = "days"           # Dias
+    hours = "hours"         # Horas (para compensatorios)
 
 
 class AccrualType(str, PyEnum):
     """Tipo de acumulacion del saldo"""
-    ANNUAL = "annual"           # Acumulacion anual (vacaciones)
-    FIXED = "fixed"             # Fondo fijo (incapacidad)
-    OVERTIME = "overtime"       # Por horas extra (compensatorio)
-    MANUAL = "manual"           # Asignacion manual
+    annual = "annual"           # Acumulacion anual (vacaciones)
+    fixed = "fixed"             # Fondo fijo (incapacidad)
+    overtime = "overtime"       # Por horas extra (compensatorio)
+    manual = "manual"           # Asignacion manual
 
 
 class TransactionType(str, PyEnum):
     """Tipo de transaccion"""
-    CREDIT = "credit"           # Acreditacion (suma)
-    DEBIT = "debit"             # Uso/Descuento (resta)
-    ADJUSTMENT = "adjustment"   # Ajuste manual
-    EXPIRATION = "expiration"   # Vencimiento
+    credit = "credit"           # Acreditacion (suma)
+    debit = "debit"             # Uso/Descuento (resta)
+    adjustment = "adjustment"   # Ajuste manual
+    expiration = "expiration"   # Vencimiento
 
 
 class LeavePolicy(Base):
@@ -66,10 +66,10 @@ class LeavePolicy(Base):
 
     # Configuracion
     unit: Mapped[LeaveUnit] = mapped_column(
-        Enum(LeaveUnit), nullable=False, default=LeaveUnit.DAYS
+        Enum(LeaveUnit), nullable=False, default=LeaveUnit.days
     )
     accrual_type: Mapped[AccrualType] = mapped_column(
-        Enum(AccrualType), nullable=False, default=AccrualType.ANNUAL
+        Enum(AccrualType), nullable=False, default=AccrualType.annual
     )
 
     # Cantidad base por periodo (ej: 15 dias/anio)

--- a/backend/app/schemas/leave_balance.py
+++ b/backend/app/schemas/leave_balance.py
@@ -1,0 +1,214 @@
+"""
+Leave Balance Schemas - Saldos Laborales
+"""
+from datetime import date, datetime
+from decimal import Decimal
+from uuid import UUID
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class LeaveUnitEnum(str, Enum):
+    days = "days"
+    hours = "hours"
+
+
+class AccrualTypeEnum(str, Enum):
+    annual = "annual"
+    fixed = "fixed"
+    overtime = "overtime"
+    manual = "manual"
+
+
+class TransactionTypeEnum(str, Enum):
+    credit = "credit"
+    debit = "debit"
+    adjustment = "adjustment"
+    expiration = "expiration"
+
+
+# ============ Leave Policy Schemas ============
+
+class LeavePolicyBase(BaseModel):
+    code: str = Field(..., min_length=1, max_length=50)
+    name: str = Field(..., min_length=1, max_length=100)
+    description: str | None = None
+    unit: LeaveUnitEnum = LeaveUnitEnum.days
+    accrual_type: AccrualTypeEnum = AccrualTypeEnum.annual
+    base_amount: Decimal = Field(default=Decimal("0"), ge=0)
+    increment_per_years: Decimal = Field(default=Decimal("0"), ge=0)
+    years_for_increment: int = Field(default=5, ge=1)
+    max_amount: Decimal | None = None
+    expires_after_days: int | None = None
+    allow_carryover: bool = False
+    max_carryover: Decimal | None = None
+    color: str = Field(default="#3b82f6", pattern=r'^#[0-9a-fA-F]{6}$')
+
+
+class LeavePolicyCreate(LeavePolicyBase):
+    pass
+
+
+class LeavePolicyUpdate(BaseModel):
+    code: str | None = None
+    name: str | None = None
+    description: str | None = None
+    unit: LeaveUnitEnum | None = None
+    accrual_type: AccrualTypeEnum | None = None
+    base_amount: Decimal | None = None
+    increment_per_years: Decimal | None = None
+    years_for_increment: int | None = None
+    max_amount: Decimal | None = None
+    expires_after_days: int | None = None
+    allow_carryover: bool | None = None
+    max_carryover: Decimal | None = None
+    color: str | None = None
+    is_active: bool | None = None
+
+
+class LeavePolicyResponse(LeavePolicyBase):
+    id: UUID
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+# ============ Leave Balance Schemas ============
+
+class LeaveBalanceBase(BaseModel):
+    employee_id: UUID
+    policy_id: UUID
+    period_year: int = Field(..., ge=2000, le=2100)
+    period_start: date
+    period_end: date
+
+
+class LeaveBalanceCreate(LeaveBalanceBase):
+    initial_balance: Decimal = Field(default=Decimal("0"), ge=0)
+    carryover_amount: Decimal = Field(default=Decimal("0"), ge=0)
+
+
+class LeaveBalanceUpdate(BaseModel):
+    initial_balance: Decimal | None = None
+    current_balance: Decimal | None = None
+    carryover_amount: Decimal | None = None
+
+
+class LeaveBalanceResponse(LeaveBalanceBase):
+    id: UUID
+    initial_balance: Decimal
+    current_balance: Decimal
+    used_amount: Decimal
+    pending_amount: Decimal
+    carryover_amount: Decimal
+    available_balance: Decimal
+    created_at: datetime
+    updated_at: datetime
+
+    # Nested info
+    policy_name: str | None = None
+    policy_code: str | None = None
+    policy_unit: LeaveUnitEnum | None = None
+    policy_color: str | None = None
+
+    class Config:
+        from_attributes = True
+
+
+# ============ Leave Transaction Schemas ============
+
+class LeaveTransactionBase(BaseModel):
+    balance_id: UUID
+    transaction_type: TransactionTypeEnum
+    amount: Decimal = Field(..., gt=0)
+    description: str | None = None
+
+
+class LeaveTransactionCreate(LeaveTransactionBase):
+    schedule_exception_id: UUID | None = None
+    usage_start_date: date | None = None
+    usage_end_date: date | None = None
+
+
+class LeaveTransactionResponse(LeaveTransactionBase):
+    id: UUID
+    balance_before: Decimal
+    balance_after: Decimal
+    schedule_exception_id: UUID | None = None
+    usage_start_date: date | None = None
+    usage_end_date: date | None = None
+    created_at: datetime
+    created_by: UUID | None = None
+
+    class Config:
+        from_attributes = True
+
+
+# ============ Employee Balance Summary ============
+
+class EmployeeBalanceSummary(BaseModel):
+    """Resumen de saldos de un empleado para la vista principal"""
+    employee_id: UUID
+    employee_code: str
+    first_name: str
+    last_name: str
+    department_name: str | None = None
+
+    # Lista de saldos activos
+    balances: list[LeaveBalanceResponse] = []
+
+
+class EmployeeBalanceDetail(BaseModel):
+    """Detalle expandido con historial de transacciones"""
+    employee_id: UUID
+    employee_code: str
+    first_name: str
+    last_name: str
+    department_name: str | None = None
+    hire_date: date | None = None
+    years_of_service: int = 0
+
+    balance: LeaveBalanceResponse
+    transactions: list[LeaveTransactionResponse] = []
+
+
+# ============ Bulk Operations ============
+
+class BulkAccrualCreate(BaseModel):
+    """Acreditacion masiva de saldos (ej: vacaciones anuales)"""
+    policy_id: UUID
+    period_year: int = Field(..., ge=2000, le=2100)
+    employee_ids: list[UUID] | None = None  # None = todos los activos
+
+
+class BalanceCalculationRequest(BaseModel):
+    """Solicitud para calcular saldo de vacaciones segun antiguedad"""
+    employee_id: UUID
+    policy_id: UUID
+    period_year: int
+
+
+class BalanceCalculationResponse(BaseModel):
+    """Respuesta del calculo de saldo"""
+    employee_id: UUID
+    policy_id: UUID
+    period_year: int
+    years_of_service: int
+    calculated_amount: Decimal
+    base_amount: Decimal
+    increment_amount: Decimal
+
+
+# ============ Filters ============
+
+class LeaveBalanceFilters(BaseModel):
+    """Filtros para la lista de saldos"""
+    search: str | None = None
+    policy_id: UUID | None = None
+    department_id: UUID | None = None
+    employee_id: UUID | None = None
+    period_year: int | None = None

--- a/backend/app/schemas/schedule.py
+++ b/backend/app/schemas/schedule.py
@@ -135,8 +135,15 @@ class ScheduleExceptionResponse(ScheduleExceptionBase):
 # Bulk Assignment for Calendar View
 class BulkAssignmentCreate(BaseModel):
     employee_ids: list[UUID]
-    dates: list[date]
+    # Option 1: Specific dates
+    dates: list[date] | None = None
+    # Option 2: Date range with optional days filter
+    start_date: date | None = None
+    end_date: date | None = None
+    days_of_week: list[int] | None = None  # 0=Monday, 6=Sunday
+    # Schedule to assign
     schedule_id: UUID | None = None
+    schedule_pattern_id: UUID | None = None  # Alias for schedule_id
     is_day_off: bool = False
 
 

--- a/backend/app/services/leave_service.py
+++ b/backend/app/services/leave_service.py
@@ -104,9 +104,9 @@ class LeaveService:
             raise ValueError("Employee or Policy not found")
 
         # Calcular saldo inicial
-        if policy.accrual_type == AccrualType.ANNUAL:
+        if policy.accrual_type == AccrualType.annual:
             _, _, initial = await self.calculate_vacation_days(employee, policy, period_year)
-        elif policy.accrual_type == AccrualType.FIXED:
+        elif policy.accrual_type == AccrualType.fixed:
             initial = policy.base_amount
         else:
             initial = Decimal("0")
@@ -147,7 +147,7 @@ class LeaveService:
         if initial > 0:
             await self.create_transaction(
                 balance_id=balance.id,
-                transaction_type=TransactionType.CREDIT,
+                transaction_type=TransactionType.credit,
                 amount=initial,
                 description=f"Acreditacion inicial periodo {period_year}"
             )
@@ -155,7 +155,7 @@ class LeaveService:
         if carryover > 0:
             await self.create_transaction(
                 balance_id=balance.id,
-                transaction_type=TransactionType.CREDIT,
+                transaction_type=TransactionType.credit,
                 amount=carryover,
                 description=f"Arrastre periodo {period_year - 1}"
             )
@@ -186,14 +186,14 @@ class LeaveService:
         balance_before = balance.current_balance
 
         # Calcular nuevo saldo
-        if transaction_type in [TransactionType.CREDIT]:
+        if transaction_type in [TransactionType.credit]:
             balance_after = balance_before + amount
             balance.current_balance = balance_after
-        elif transaction_type in [TransactionType.DEBIT, TransactionType.EXPIRATION]:
+        elif transaction_type in [TransactionType.debit, TransactionType.expiration]:
             balance_after = balance_before - amount
             balance.current_balance = balance_after
             balance.used_amount += amount
-        elif transaction_type == TransactionType.ADJUSTMENT:
+        elif transaction_type == TransactionType.adjustment:
             # Adjustment puede ser positivo o negativo
             balance_after = balance_before + amount  # amount puede ser negativo
             balance.current_balance = balance_after
@@ -266,7 +266,7 @@ class LeaveService:
         # Crear transaccion de descuento
         transaction = await self.create_transaction(
             balance_id=balance.id,
-            transaction_type=TransactionType.DEBIT,
+            transaction_type=TransactionType.debit,
             amount=Decimal(str(days)),
             description=f"{schedule_exception.exception_type.value}: {schedule_exception.description or 'Sin descripcion'}",
             schedule_exception_id=schedule_exception.id,

--- a/backend/app/services/leave_service.py
+++ b/backend/app/services/leave_service.py
@@ -1,0 +1,322 @@
+"""
+Leave Balance Service - Logica de negocio para saldos laborales
+"""
+from datetime import date, datetime
+from decimal import Decimal
+from uuid import UUID
+
+from sqlalchemy import select, func
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.employee import Employee
+from app.models.leave_balance import (
+    LeavePolicy, LeaveBalance, LeaveTransaction,
+    LeaveUnit, AccrualType, TransactionType
+)
+from app.models.schedule import ScheduleException, ExceptionType
+
+
+class LeaveService:
+    """Servicio para gestion de saldos laborales"""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def calculate_years_of_service(self, employee: Employee, as_of_date: date | None = None) -> int:
+        """Calcula anios de antiguedad del empleado"""
+        if not employee.hire_date:
+            return 0
+
+        reference_date = as_of_date or date.today()
+        delta = reference_date - employee.hire_date
+
+        return delta.days // 365
+
+    async def calculate_vacation_days(
+        self,
+        employee: Employee,
+        policy: LeavePolicy,
+        period_year: int
+    ) -> tuple[Decimal, Decimal, Decimal]:
+        """
+        Calcula dias de vacaciones segun antiguedad.
+
+        Returns:
+            Tuple[base_amount, increment_amount, total_amount]
+        """
+        # Fecha de referencia: inicio del periodo
+        reference_date = date(period_year, 1, 1)
+        years_of_service = await self.calculate_years_of_service(employee, reference_date)
+
+        base_amount = policy.base_amount
+
+        # Calcular incremento por antiguedad
+        if policy.years_for_increment > 0:
+            increments = years_of_service // policy.years_for_increment
+            increment_amount = policy.increment_per_years * Decimal(str(increments))
+        else:
+            increment_amount = Decimal("0")
+
+        total_amount = base_amount + increment_amount
+
+        # Aplicar tope maximo si existe
+        if policy.max_amount and total_amount > policy.max_amount:
+            total_amount = policy.max_amount
+
+        return base_amount, increment_amount, total_amount
+
+    async def get_or_create_balance(
+        self,
+        employee_id: UUID,
+        policy_id: UUID,
+        period_year: int
+    ) -> LeaveBalance:
+        """Obtiene o crea el saldo para un empleado/politica/periodo"""
+        # Buscar existente
+        query = select(LeaveBalance).where(
+            LeaveBalance.employee_id == employee_id,
+            LeaveBalance.policy_id == policy_id,
+            LeaveBalance.period_year == period_year
+        )
+        result = await self.db.execute(query)
+        balance = result.scalar_one_or_none()
+
+        if balance:
+            return balance
+
+        # Crear nuevo
+        period_start = date(period_year, 1, 1)
+        period_end = date(period_year, 12, 31)
+
+        # Obtener empleado y politica para calcular
+        emp_result = await self.db.execute(
+            select(Employee).where(Employee.id == employee_id)
+        )
+        employee = emp_result.scalar_one_or_none()
+
+        policy_result = await self.db.execute(
+            select(LeavePolicy).where(LeavePolicy.id == policy_id)
+        )
+        policy = policy_result.scalar_one_or_none()
+
+        if not employee or not policy:
+            raise ValueError("Employee or Policy not found")
+
+        # Calcular saldo inicial
+        if policy.accrual_type == AccrualType.ANNUAL:
+            _, _, initial = await self.calculate_vacation_days(employee, policy, period_year)
+        elif policy.accrual_type == AccrualType.FIXED:
+            initial = policy.base_amount
+        else:
+            initial = Decimal("0")
+
+        # Verificar arrastre del periodo anterior
+        carryover = Decimal("0")
+        if policy.allow_carryover:
+            prev_balance = await self.db.execute(
+                select(LeaveBalance).where(
+                    LeaveBalance.employee_id == employee_id,
+                    LeaveBalance.policy_id == policy_id,
+                    LeaveBalance.period_year == period_year - 1
+                )
+            )
+            prev = prev_balance.scalar_one_or_none()
+            if prev and prev.current_balance > 0:
+                carryover = prev.current_balance
+                if policy.max_carryover and carryover > policy.max_carryover:
+                    carryover = policy.max_carryover
+
+        balance = LeaveBalance(
+            employee_id=employee_id,
+            policy_id=policy_id,
+            period_year=period_year,
+            period_start=period_start,
+            period_end=period_end,
+            initial_balance=initial,
+            current_balance=initial + carryover,
+            used_amount=Decimal("0"),
+            pending_amount=Decimal("0"),
+            carryover_amount=carryover
+        )
+
+        self.db.add(balance)
+        await self.db.flush()
+
+        # Crear transaccion de acreditacion inicial
+        if initial > 0:
+            await self.create_transaction(
+                balance_id=balance.id,
+                transaction_type=TransactionType.CREDIT,
+                amount=initial,
+                description=f"Acreditacion inicial periodo {period_year}"
+            )
+
+        if carryover > 0:
+            await self.create_transaction(
+                balance_id=balance.id,
+                transaction_type=TransactionType.CREDIT,
+                amount=carryover,
+                description=f"Arrastre periodo {period_year - 1}"
+            )
+
+        return balance
+
+    async def create_transaction(
+        self,
+        balance_id: UUID,
+        transaction_type: TransactionType,
+        amount: Decimal,
+        description: str | None = None,
+        schedule_exception_id: UUID | None = None,
+        usage_start_date: date | None = None,
+        usage_end_date: date | None = None,
+        created_by: UUID | None = None
+    ) -> LeaveTransaction:
+        """Crea una transaccion y actualiza el saldo"""
+        # Obtener balance actual
+        result = await self.db.execute(
+            select(LeaveBalance).where(LeaveBalance.id == balance_id)
+        )
+        balance = result.scalar_one_or_none()
+
+        if not balance:
+            raise ValueError("Balance not found")
+
+        balance_before = balance.current_balance
+
+        # Calcular nuevo saldo
+        if transaction_type in [TransactionType.CREDIT]:
+            balance_after = balance_before + amount
+            balance.current_balance = balance_after
+        elif transaction_type in [TransactionType.DEBIT, TransactionType.EXPIRATION]:
+            balance_after = balance_before - amount
+            balance.current_balance = balance_after
+            balance.used_amount += amount
+        elif transaction_type == TransactionType.ADJUSTMENT:
+            # Adjustment puede ser positivo o negativo
+            balance_after = balance_before + amount  # amount puede ser negativo
+            balance.current_balance = balance_after
+
+        # Crear transaccion
+        transaction = LeaveTransaction(
+            balance_id=balance_id,
+            transaction_type=transaction_type,
+            amount=abs(amount),
+            balance_before=balance_before,
+            balance_after=balance_after,
+            schedule_exception_id=schedule_exception_id,
+            usage_start_date=usage_start_date,
+            usage_end_date=usage_end_date,
+            description=description,
+            created_by=created_by
+        )
+
+        self.db.add(transaction)
+        await self.db.flush()
+
+        return transaction
+
+    async def deduct_from_exception(
+        self,
+        schedule_exception: ScheduleException,
+        created_by: UUID | None = None
+    ) -> LeaveTransaction | None:
+        """
+        Descuenta saldo automaticamente cuando se aprueba una excepcion.
+
+        Mapeo de tipos de excepcion a politicas:
+        - vacation -> VACATION policy
+        - sick_leave -> SICK_LEAVE policy
+        - compensatory -> COMPENSATORY policy
+        """
+        if not schedule_exception.employee_id:
+            return None  # Excepciones globales (feriados) no descuentan
+
+        # Mapear tipo de excepcion a codigo de politica
+        exception_to_policy = {
+            ExceptionType.VACATION: "VACATION",
+            ExceptionType.SICK_LEAVE: "SICK_LEAVE",
+        }
+
+        policy_code = exception_to_policy.get(schedule_exception.exception_type)
+        if not policy_code:
+            return None  # Este tipo no descuenta saldo
+
+        # Buscar politica
+        policy_result = await self.db.execute(
+            select(LeavePolicy).where(LeavePolicy.code == policy_code)
+        )
+        policy = policy_result.scalar_one_or_none()
+
+        if not policy:
+            return None
+
+        # Calcular dias a descontar
+        days = (schedule_exception.end_date - schedule_exception.start_date).days + 1
+
+        # Obtener o crear balance para el periodo
+        period_year = schedule_exception.start_date.year
+        balance = await self.get_or_create_balance(
+            employee_id=schedule_exception.employee_id,
+            policy_id=policy.id,
+            period_year=period_year
+        )
+
+        # Crear transaccion de descuento
+        transaction = await self.create_transaction(
+            balance_id=balance.id,
+            transaction_type=TransactionType.DEBIT,
+            amount=Decimal(str(days)),
+            description=f"{schedule_exception.exception_type.value}: {schedule_exception.description or 'Sin descripcion'}",
+            schedule_exception_id=schedule_exception.id,
+            usage_start_date=schedule_exception.start_date,
+            usage_end_date=schedule_exception.end_date,
+            created_by=created_by
+        )
+
+        await self.db.commit()
+
+        return transaction
+
+    async def bulk_accrual(
+        self,
+        policy_id: UUID,
+        period_year: int,
+        employee_ids: list[UUID] | None = None
+    ) -> int:
+        """
+        Acreditacion masiva de saldos para un periodo.
+
+        Args:
+            policy_id: ID de la politica
+            period_year: Anio del periodo
+            employee_ids: Lista de empleados (None = todos los activos)
+
+        Returns:
+            Cantidad de saldos creados/actualizados
+        """
+        # Obtener empleados
+        if employee_ids:
+            emp_query = select(Employee).where(
+                Employee.id.in_(employee_ids),
+                Employee.is_active == True
+            )
+        else:
+            emp_query = select(Employee).where(Employee.is_active == True)
+
+        result = await self.db.execute(emp_query)
+        employees = result.scalars().all()
+
+        count = 0
+        for employee in employees:
+            await self.get_or_create_balance(
+                employee_id=employee.id,
+                policy_id=policy_id,
+                period_year=period_year
+            )
+            count += 1
+
+        await self.db.commit()
+
+        return count

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -65,8 +65,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "8kB"
+                  "maximumWarning": "8kB",
+                  "maximumError": "12kB"
                 }
               ],
               "outputHashing": "all"

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -74,6 +74,13 @@ export const routes: Routes = [
             (m) => m.SchedulesComponent
           ),
       },
+      {
+        path: 'leave-balances',
+        loadComponent: () =>
+          import('./features/admin/pages/leave-balances/leave-balances.component').then(
+            (m) => m.LeaveBalancesComponent
+          ),
+      },
     ],
   },
   {

--- a/frontend/src/app/app.ts
+++ b/frontend/src/app/app.ts
@@ -1,10 +1,14 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { ToastComponent } from './shared/components/toast/toast.component';
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
-  template: '<router-outlet />',
+  imports: [RouterOutlet, ToastComponent],
+  template: `
+    <router-outlet />
+    <app-toast />
+  `,
   styles: [],
 })
 export class App {}

--- a/frontend/src/app/core/models/leave-balance.model.ts
+++ b/frontend/src/app/core/models/leave-balance.model.ts
@@ -1,0 +1,225 @@
+/**
+ * Leave Balance Models - Saldos Laborales
+ *
+ * Tipos de saldo:
+ * - Vacaciones (dias): acumulacion anual segun antiguedad
+ * - Incapacidad (dias): fondo fijo anual
+ * - Horas Compensatorias (horas:minutos): por horas extra trabajadas
+ */
+
+// ============ Enums ============
+
+export type LeaveUnit = 'days' | 'hours';
+
+export type AccrualType = 'annual' | 'fixed' | 'overtime' | 'manual';
+
+export type TransactionType = 'credit' | 'debit' | 'adjustment' | 'expiration';
+
+// ============ Leave Policy ============
+
+export interface LeavePolicy {
+  id: string;
+  code: string;
+  name: string;
+  description: string | null;
+  unit: LeaveUnit;
+  accrual_type: AccrualType;
+  base_amount: number;
+  increment_per_years: number;
+  years_for_increment: number;
+  max_amount: number | null;
+  expires_after_days: number | null;
+  allow_carryover: boolean;
+  max_carryover: number | null;
+  color: string;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LeavePolicyCreate {
+  code: string;
+  name: string;
+  description?: string;
+  unit?: LeaveUnit;
+  accrual_type?: AccrualType;
+  base_amount?: number;
+  increment_per_years?: number;
+  years_for_increment?: number;
+  max_amount?: number | null;
+  expires_after_days?: number | null;
+  allow_carryover?: boolean;
+  max_carryover?: number | null;
+  color?: string;
+}
+
+export interface LeavePolicyUpdate {
+  code?: string;
+  name?: string;
+  description?: string;
+  unit?: LeaveUnit;
+  accrual_type?: AccrualType;
+  base_amount?: number;
+  increment_per_years?: number;
+  years_for_increment?: number;
+  max_amount?: number | null;
+  expires_after_days?: number | null;
+  allow_carryover?: boolean;
+  max_carryover?: number | null;
+  color?: string;
+  is_active?: boolean;
+}
+
+// ============ Leave Balance ============
+
+export interface LeaveBalance {
+  id: string;
+  employee_id: string;
+  policy_id: string;
+  period_year: number;
+  period_start: string;
+  period_end: string;
+  initial_balance: number;
+  current_balance: number;
+  used_amount: number;
+  pending_amount: number;
+  carryover_amount: number;
+  available_balance: number;
+  created_at: string;
+  updated_at: string;
+  // Nested policy info
+  policy_name: string | null;
+  policy_code: string | null;
+  policy_unit: LeaveUnit | null;
+  policy_color: string | null;
+}
+
+export interface LeaveBalanceCreate {
+  employee_id: string;
+  policy_id: string;
+  period_year: number;
+  period_start: string;
+  period_end: string;
+  initial_balance?: number;
+  carryover_amount?: number;
+}
+
+// ============ Leave Transaction ============
+
+export interface LeaveTransaction {
+  id: string;
+  balance_id: string;
+  transaction_type: TransactionType;
+  amount: number;
+  balance_before: number;
+  balance_after: number;
+  schedule_exception_id: string | null;
+  usage_start_date: string | null;
+  usage_end_date: string | null;
+  description: string | null;
+  created_at: string;
+  created_by: string | null;
+}
+
+export interface LeaveTransactionCreate {
+  balance_id: string;
+  transaction_type: TransactionType;
+  amount: number;
+  description?: string;
+  schedule_exception_id?: string;
+  usage_start_date?: string;
+  usage_end_date?: string;
+}
+
+// ============ Employee Summary & Detail ============
+
+export interface EmployeeBalanceSummary {
+  employee_id: string;
+  employee_code: string;
+  first_name: string;
+  last_name: string;
+  department_name: string | null;
+  balances: LeaveBalance[];
+}
+
+export interface EmployeeBalanceDetail {
+  employee_id: string;
+  employee_code: string;
+  first_name: string;
+  last_name: string;
+  department_name: string | null;
+  hire_date: string | null;
+  years_of_service: number;
+  balance: LeaveBalance;
+  transactions: LeaveTransaction[];
+}
+
+// ============ Bulk Operations ============
+
+export interface BulkAccrualCreate {
+  policy_id: string;
+  period_year: number;
+  employee_ids?: string[];
+}
+
+export interface BalanceCalculationRequest {
+  employee_id: string;
+  policy_id: string;
+  period_year: number;
+}
+
+export interface BalanceCalculationResponse {
+  employee_id: string;
+  policy_id: string;
+  period_year: number;
+  years_of_service: number;
+  calculated_amount: number;
+  base_amount: number;
+  increment_amount: number;
+}
+
+// ============ UI Helpers ============
+
+export interface LeaveBalanceFilters {
+  search: string;
+  policyId: string;
+  departmentId: string;
+  employeeId: string;
+  periodYear: number;
+}
+
+export const LEAVE_UNIT_LABELS: Record<LeaveUnit, string> = {
+  days: 'Dias',
+  hours: 'Horas',
+};
+
+export const ACCRUAL_TYPE_LABELS: Record<AccrualType, string> = {
+  annual: 'Anual',
+  fixed: 'Fijo',
+  overtime: 'Horas Extra',
+  manual: 'Manual',
+};
+
+export const TRANSACTION_TYPE_LABELS: Record<TransactionType, string> = {
+  credit: 'Acreditacion',
+  debit: 'Uso',
+  adjustment: 'Ajuste',
+  expiration: 'Vencimiento',
+};
+
+export const TRANSACTION_TYPE_COLORS: Record<TransactionType, string> = {
+  credit: '#22c55e',     // green
+  debit: '#ef4444',      // red
+  adjustment: '#f59e0b', // amber
+  expiration: '#6b7280', // gray
+};
+
+// Helper function to format balance display
+export function formatBalance(amount: number, unit: LeaveUnit): string {
+  if (unit === 'hours') {
+    const hours = Math.floor(amount);
+    const minutes = Math.round((amount - hours) * 60);
+    return `${hours}h ${minutes}m`;
+  }
+  return `${amount} ${amount === 1 ? 'dia' : 'dias'}`;
+}

--- a/frontend/src/app/core/services/leave-balance.service.ts
+++ b/frontend/src/app/core/services/leave-balance.service.ts
@@ -1,0 +1,119 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService } from './api.service';
+import {
+  LeavePolicy,
+  LeavePolicyCreate,
+  LeavePolicyUpdate,
+  LeaveBalance,
+  LeaveBalanceCreate,
+  LeaveTransaction,
+  LeaveTransactionCreate,
+  EmployeeBalanceSummary,
+  EmployeeBalanceDetail,
+  BulkAccrualCreate,
+  BalanceCalculationRequest,
+  BalanceCalculationResponse,
+} from '../models/leave-balance.model';
+
+export interface LeaveBalanceListParams {
+  search?: string;
+  policy_id?: string;
+  department_id?: string;
+  employee_id?: string;
+  period_year?: number;
+  skip?: number;
+  limit?: number;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class LeaveBalanceService {
+  private readonly api = inject(ApiService);
+  private readonly basePath = '/leave-balances';
+
+  // ============ Policies ============
+
+  getPolicies(activeOnly = true): Observable<LeavePolicy[]> {
+    return this.api.get<LeavePolicy[]>(`${this.basePath}/policies`, {
+      active_only: activeOnly,
+    });
+  }
+
+  getPolicy(id: string): Observable<LeavePolicy> {
+    return this.api.get<LeavePolicy>(`${this.basePath}/policies/${id}`);
+  }
+
+  createPolicy(policy: LeavePolicyCreate): Observable<LeavePolicy> {
+    return this.api.post<LeavePolicy>(`${this.basePath}/policies`, policy);
+  }
+
+  updatePolicy(id: string, policy: LeavePolicyUpdate): Observable<LeavePolicy> {
+    return this.api.patch<LeavePolicy>(`${this.basePath}/policies/${id}`, policy);
+  }
+
+  deletePolicy(id: string): Observable<void> {
+    return this.api.delete<void>(`${this.basePath}/policies/${id}`);
+  }
+
+  // ============ Balances ============
+
+  getBalances(params: LeaveBalanceListParams = {}): Observable<EmployeeBalanceSummary[]> {
+    const queryParams: Record<string, string | number | boolean> = {};
+
+    if (params.search) queryParams['search'] = params.search;
+    if (params.policy_id) queryParams['policy_id'] = params.policy_id;
+    if (params.department_id) queryParams['department_id'] = params.department_id;
+    if (params.employee_id) queryParams['employee_id'] = params.employee_id;
+    if (params.period_year) queryParams['period_year'] = params.period_year;
+    if (params.skip !== undefined) queryParams['skip'] = params.skip;
+    if (params.limit !== undefined) queryParams['limit'] = params.limit;
+
+    return this.api.get<EmployeeBalanceSummary[]>(this.basePath, queryParams);
+  }
+
+  getEmployeeBalanceDetail(
+    employeeId: string,
+    policyId: string,
+    periodYear?: number
+  ): Observable<EmployeeBalanceDetail> {
+    const params: Record<string, string | number> = { policy_id: policyId };
+    if (periodYear) params['period_year'] = periodYear;
+
+    return this.api.get<EmployeeBalanceDetail>(
+      `${this.basePath}/employee/${employeeId}/detail`,
+      params
+    );
+  }
+
+  createBalance(balance: LeaveBalanceCreate): Observable<LeaveBalance> {
+    return this.api.post<LeaveBalance>(this.basePath, balance);
+  }
+
+  // ============ Bulk Operations ============
+
+  bulkAccrual(data: BulkAccrualCreate): Observable<{ message: string; count: number }> {
+    return this.api.post<{ message: string; count: number }>(
+      `${this.basePath}/bulk-accrual`,
+      data
+    );
+  }
+
+  calculateBalance(request: BalanceCalculationRequest): Observable<BalanceCalculationResponse> {
+    return this.api.post<BalanceCalculationResponse>(
+      `${this.basePath}/calculate`,
+      request
+    );
+  }
+
+  // ============ Transactions ============
+
+  getTransactions(balanceId: string): Observable<LeaveTransaction[]> {
+    return this.api.get<LeaveTransaction[]>(`${this.basePath}/transactions/${balanceId}`);
+  }
+
+  createTransaction(transaction: LeaveTransactionCreate): Observable<LeaveTransaction> {
+    return this.api.post<LeaveTransaction>(`${this.basePath}/transactions`, transaction);
+  }
+}

--- a/frontend/src/app/core/services/schedule.service.ts
+++ b/frontend/src/app/core/services/schedule.service.ts
@@ -58,8 +58,8 @@ export class ScheduleService {
 
   createBulkAssignments(
     bulk: BulkScheduleAssignment
-  ): Observable<{ created: number; message: string }> {
-    return this.api.post<{ created: number; message: string }>(
+  ): Observable<{ created: number; updated: number }> {
+    return this.api.post<{ created: number; updated: number }>(
       '/schedules/assignments/bulk',
       bulk
     );

--- a/frontend/src/app/core/services/toast.service.ts
+++ b/frontend/src/app/core/services/toast.service.ts
@@ -1,0 +1,51 @@
+import { Injectable, signal } from '@angular/core';
+
+export type ToastType = 'success' | 'error' | 'warning' | 'info';
+
+export interface Toast {
+  id: number;
+  message: string;
+  type: ToastType;
+  duration: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ToastService {
+  private nextId = 1;
+  readonly toasts = signal<Toast[]>([]);
+
+  show(message: string, type: ToastType = 'info', duration = 4000): void {
+    const id = this.nextId++;
+    const toast: Toast = { id, message, type, duration };
+
+    this.toasts.update((current) => [...current, toast]);
+
+    if (duration > 0) {
+      setTimeout(() => this.dismiss(id), duration);
+    }
+  }
+
+  success(message: string, duration = 4000): void {
+    this.show(message, 'success', duration);
+  }
+
+  error(message: string, duration = 5000): void {
+    this.show(message, 'error', duration);
+  }
+
+  warning(message: string, duration = 4000): void {
+    this.show(message, 'warning', duration);
+  }
+
+  info(message: string, duration = 4000): void {
+    this.show(message, 'info', duration);
+  }
+
+  dismiss(id: number): void {
+    this.toasts.update((current) => current.filter((t) => t.id !== id));
+  }
+
+  clear(): void {
+    this.toasts.set([]);
+  }
+}

--- a/frontend/src/app/features/admin/pages/dashboard/dashboard.component.ts
+++ b/frontend/src/app/features/admin/pages/dashboard/dashboard.component.ts
@@ -72,6 +72,11 @@ import { Employee } from '../../../../core/models/employee.model';
           <h3>Horarios</h3>
           <p>Calendario y patrones de horarios</p>
         </a>
+        <a routerLink="/admin/leave-balances" class="nav-card">
+          <div class="nav-icon">📊</div>
+          <h3>Saldos Laborales</h3>
+          <p>Vacaciones, incapacidades y compensatorios</p>
+        </a>
         <a routerLink="/admin/settings" class="nav-card">
           <div class="nav-icon">⚙️</div>
           <h3>Configuración</h3>

--- a/frontend/src/app/features/admin/pages/leave-balances/leave-balances.component.ts
+++ b/frontend/src/app/features/admin/pages/leave-balances/leave-balances.component.ts
@@ -1,0 +1,1059 @@
+import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { forkJoin } from 'rxjs';
+
+import { LeaveBalanceService } from '../../../../core/services/leave-balance.service';
+import { DepartmentService } from '../../../../core/services/department.service';
+import { EmployeeService } from '../../../../core/services/employee.service';
+import { Department } from '../../../../core/models/department.model';
+import { Employee } from '../../../../core/models/employee.model';
+import {
+  LeavePolicy,
+  EmployeeBalanceSummary,
+  EmployeeBalanceDetail,
+  LeaveTransaction,
+  formatBalance,
+  TRANSACTION_TYPE_LABELS,
+  TRANSACTION_TYPE_COLORS,
+  LEAVE_UNIT_LABELS,
+} from '../../../../core/models/leave-balance.model';
+
+@Component({
+  selector: 'app-leave-balances',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink],
+  template: `
+    <div class="leave-balances-page">
+      <header class="header">
+        <div>
+          <a routerLink="/admin/dashboard" class="back-link">← Dashboard</a>
+          <h1>Saldos Laborales</h1>
+        </div>
+        <div class="header-actions">
+          <button class="btn btn-secondary" (click)="openBulkAccrualModal()">
+            Acreditacion Masiva
+          </button>
+          <button class="btn btn-primary" (click)="openPoliciesModal()">
+            Configurar Politicas
+          </button>
+        </div>
+      </header>
+
+      <!-- Filters -->
+      <div class="filters-container">
+        <div class="filter-group">
+          <label>Buscar</label>
+          <input
+            type="text"
+            [(ngModel)]="filters.search"
+            placeholder="Nombre o codigo..."
+            (input)="onSearchChange()"
+          />
+        </div>
+        <div class="filter-group">
+          <label>Tipo de Saldo</label>
+          <select [(ngModel)]="filters.policyId" (change)="loadBalances()">
+            <option value="">Todos</option>
+            @for (policy of policies(); track policy.id) {
+              <option [value]="policy.id">{{ policy.name }}</option>
+            }
+          </select>
+        </div>
+        <div class="filter-group">
+          <label>Departamento</label>
+          <select [(ngModel)]="filters.departmentId" (change)="loadBalances()">
+            <option value="">Todos</option>
+            @for (dept of departments(); track dept.id) {
+              <option [value]="dept.id">{{ dept.name }}</option>
+            }
+          </select>
+        </div>
+        <div class="filter-group">
+          <label>Periodo</label>
+          <select [(ngModel)]="filters.periodYear" (change)="loadBalances()">
+            @for (year of availableYears(); track year) {
+              <option [value]="year">{{ year }}</option>
+            }
+          </select>
+        </div>
+      </div>
+
+      <!-- Main Table -->
+      <div class="table-container">
+        <table>
+          <thead>
+            <tr>
+              <th class="expand-col"></th>
+              <th>Codigo</th>
+              <th>Nombre</th>
+              <th>Departamento</th>
+              @for (policy of policies(); track policy.id) {
+                <th class="balance-col" [style.border-left]="'3px solid ' + policy.color">
+                  {{ policy.name }}
+                </th>
+              }
+            </tr>
+          </thead>
+          <tbody>
+            @for (employee of balanceSummaries(); track employee.employee_id) {
+              <tr
+                class="employee-row"
+                [class.expanded]="isExpanded(employee.employee_id)"
+                (click)="toggleExpand(employee)"
+              >
+                <td class="expand-col">
+                  <span class="expand-icon">
+                    {{ isExpanded(employee.employee_id) ? '▼' : '▶' }}
+                  </span>
+                </td>
+                <td>{{ employee.employee_code }}</td>
+                <td>{{ employee.first_name }} {{ employee.last_name }}</td>
+                <td>{{ employee.department_name || '-' }}</td>
+                @for (policy of policies(); track policy.id) {
+                  <td class="balance-col">
+                    @if (getBalanceForPolicy(employee, policy.id); as balance) {
+                      <div class="balance-display" [style.color]="policy.color">
+                        <span class="balance-available">
+                          {{ formatBalanceValue(balance.available_balance, balance.policy_unit) }}
+                        </span>
+                        <span class="balance-used">
+                          ({{ formatBalanceValue(balance.used_amount, balance.policy_unit) }} usados)
+                        </span>
+                      </div>
+                    } @else {
+                      <span class="no-balance">-</span>
+                    }
+                  </td>
+                }
+              </tr>
+              <!-- Expanded Detail Row -->
+              @if (isExpanded(employee.employee_id) && expandedDetail()) {
+                <tr class="detail-row">
+                  <td [attr.colspan]="4 + policies().length">
+                    <div class="detail-container">
+                      <div class="detail-header">
+                        <h3>
+                          Historial: {{ expandedDetail()!.balance.policy_name }}
+                          - {{ expandedDetail()!.first_name }} {{ expandedDetail()!.last_name }}
+                        </h3>
+                        <div class="detail-info">
+                          <span>Antiguedad: {{ expandedDetail()!.years_of_service }} anios</span>
+                          @if (expandedDetail()!.hire_date) {
+                            <span>Ingreso: {{ expandedDetail()!.hire_date | date:'dd/MM/yyyy' }}</span>
+                          }
+                        </div>
+                      </div>
+
+                      <div class="balance-summary">
+                        <div class="summary-card">
+                          <span class="label">Inicial</span>
+                          <span class="value">
+                            {{ formatBalanceValue(
+                              expandedDetail()!.balance.initial_balance,
+                              expandedDetail()!.balance.policy_unit
+                            ) }}
+                          </span>
+                        </div>
+                        <div class="summary-card">
+                          <span class="label">Arrastre</span>
+                          <span class="value">
+                            {{ formatBalanceValue(
+                              expandedDetail()!.balance.carryover_amount,
+                              expandedDetail()!.balance.policy_unit
+                            ) }}
+                          </span>
+                        </div>
+                        <div class="summary-card">
+                          <span class="label">Usado</span>
+                          <span class="value used">
+                            {{ formatBalanceValue(
+                              expandedDetail()!.balance.used_amount,
+                              expandedDetail()!.balance.policy_unit
+                            ) }}
+                          </span>
+                        </div>
+                        <div class="summary-card highlight">
+                          <span class="label">Disponible</span>
+                          <span class="value">
+                            {{ formatBalanceValue(
+                              expandedDetail()!.balance.available_balance,
+                              expandedDetail()!.balance.policy_unit
+                            ) }}
+                          </span>
+                        </div>
+                      </div>
+
+                      <!-- Transactions Table -->
+                      <div class="transactions-table">
+                        <table>
+                          <thead>
+                            <tr>
+                              <th>Fecha</th>
+                              <th>Tipo</th>
+                              <th>Cantidad</th>
+                              <th>Fecha Inicio</th>
+                              <th>Fecha Fin</th>
+                              <th>Descripcion</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            @for (trans of expandedDetail()!.transactions; track trans.id) {
+                              <tr>
+                                <td>{{ trans.created_at | date:'dd/MM/yyyy HH:mm' }}</td>
+                                <td>
+                                  <span
+                                    class="trans-type"
+                                    [style.background]="getTransactionColor(trans.transaction_type)"
+                                  >
+                                    {{ getTransactionLabel(trans.transaction_type) }}
+                                  </span>
+                                </td>
+                                <td
+                                  [class.positive]="trans.transaction_type === 'credit'"
+                                  [class.negative]="trans.transaction_type === 'debit'"
+                                >
+                                  {{ trans.transaction_type === 'debit' ? '-' : '+' }}
+                                  {{ formatBalanceValue(trans.amount, expandedDetail()!.balance.policy_unit) }}
+                                </td>
+                                <td>{{ trans.usage_start_date | date:'dd/MM/yyyy' }}</td>
+                                <td>{{ trans.usage_end_date | date:'dd/MM/yyyy' }}</td>
+                                <td>{{ trans.description || '-' }}</td>
+                              </tr>
+                            } @empty {
+                              <tr>
+                                <td colspan="6" class="empty-row">Sin movimientos</td>
+                              </tr>
+                            }
+                          </tbody>
+                        </table>
+                      </div>
+
+                      <div class="detail-actions">
+                        <button class="btn btn-sm btn-primary" (click)="openAddTransactionModal()">
+                          + Agregar Movimiento
+                        </button>
+                      </div>
+                    </div>
+                  </td>
+                </tr>
+              }
+            } @empty {
+              <tr>
+                <td [attr.colspan]="4 + policies().length" class="empty-table">
+                  No se encontraron empleados con saldos
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+
+      @if (loading()) {
+        <div class="loading-overlay">
+          <div class="spinner"></div>
+        </div>
+      }
+
+      <!-- Bulk Accrual Modal -->
+      @if (showBulkAccrualModal()) {
+        <div class="modal-overlay" (click)="closeBulkAccrualModal()">
+          <div class="modal" (click)="$event.stopPropagation()">
+            <h2>Acreditacion Masiva de Saldos</h2>
+            <form (ngSubmit)="executeBulkAccrual()">
+              <div class="form-group">
+                <label>Tipo de Saldo *</label>
+                <select [(ngModel)]="bulkAccrual.policy_id" name="policyId" required>
+                  <option value="">-- Seleccionar --</option>
+                  @for (policy of policies(); track policy.id) {
+                    <option [value]="policy.id">{{ policy.name }}</option>
+                  }
+                </select>
+              </div>
+              <div class="form-group">
+                <label>Periodo (Anio) *</label>
+                <input
+                  type="number"
+                  [(ngModel)]="bulkAccrual.period_year"
+                  name="periodYear"
+                  required
+                  min="2020"
+                  max="2100"
+                />
+              </div>
+              <p class="info-text">
+                Se acreditaran los saldos a todos los empleados activos
+                segun la configuracion de la politica seleccionada.
+              </p>
+              <div class="modal-actions">
+                <button type="button" class="btn btn-secondary" (click)="closeBulkAccrualModal()">
+                  Cancelar
+                </button>
+                <button type="submit" class="btn btn-primary">
+                  Ejecutar Acreditacion
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      }
+
+      <!-- Policies Modal -->
+      @if (showPoliciesModal()) {
+        <div class="modal-overlay" (click)="closePoliciesModal()">
+          <div class="modal modal-wide" (click)="$event.stopPropagation()">
+            <h2>Configuracion de Politicas de Saldo</h2>
+            <div class="policies-list">
+              @for (policy of policies(); track policy.id) {
+                <div class="policy-card" [style.border-left-color]="policy.color">
+                  <div class="policy-header">
+                    <span class="policy-name">{{ policy.name }}</span>
+                    <span class="policy-code">{{ policy.code }}</span>
+                  </div>
+                  <div class="policy-details">
+                    <span>Unidad: {{ getUnitLabel(policy.unit) }}</span>
+                    <span>Base: {{ policy.base_amount }} {{ getUnitLabel(policy.unit) }}</span>
+                    @if (policy.increment_per_years > 0) {
+                      <span>
+                        +{{ policy.increment_per_years }} cada {{ policy.years_for_increment }} anios
+                      </span>
+                    }
+                    @if (policy.max_amount) {
+                      <span>Max: {{ policy.max_amount }}</span>
+                    }
+                  </div>
+                </div>
+              }
+            </div>
+            <div class="modal-actions">
+              <button class="btn btn-secondary" (click)="closePoliciesModal()">
+                Cerrar
+              </button>
+            </div>
+          </div>
+        </div>
+      }
+
+      <!-- Add Transaction Modal -->
+      @if (showTransactionModal()) {
+        <div class="modal-overlay" (click)="closeTransactionModal()">
+          <div class="modal" (click)="$event.stopPropagation()">
+            <h2>Agregar Movimiento</h2>
+            <form (ngSubmit)="saveTransaction()">
+              <div class="form-group">
+                <label>Tipo *</label>
+                <select [(ngModel)]="newTransaction.transaction_type" name="type" required>
+                  <option value="credit">Acreditacion (+)</option>
+                  <option value="debit">Uso (-)</option>
+                  <option value="adjustment">Ajuste</option>
+                </select>
+              </div>
+              <div class="form-group">
+                <label>Cantidad *</label>
+                <input
+                  type="number"
+                  [(ngModel)]="newTransaction.amount"
+                  name="amount"
+                  required
+                  min="0.01"
+                  step="0.01"
+                />
+              </div>
+              <div class="form-row">
+                <div class="form-group">
+                  <label>Fecha Inicio</label>
+                  <input
+                    type="date"
+                    [(ngModel)]="newTransaction.usage_start_date"
+                    name="startDate"
+                  />
+                </div>
+                <div class="form-group">
+                  <label>Fecha Fin</label>
+                  <input
+                    type="date"
+                    [(ngModel)]="newTransaction.usage_end_date"
+                    name="endDate"
+                  />
+                </div>
+              </div>
+              <div class="form-group">
+                <label>Descripcion</label>
+                <textarea
+                  [(ngModel)]="newTransaction.description"
+                  name="description"
+                  rows="2"
+                ></textarea>
+              </div>
+              <div class="modal-actions">
+                <button type="button" class="btn btn-secondary" (click)="closeTransactionModal()">
+                  Cancelar
+                </button>
+                <button type="submit" class="btn btn-primary">
+                  Guardar
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      }
+    </div>
+  `,
+  styles: [`
+    .leave-balances-page {
+      min-height: 100vh;
+      background: #f3f4f6;
+      padding: 2rem;
+    }
+
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-end;
+      margin-bottom: 1.5rem;
+    }
+
+    .back-link {
+      color: #6b7280;
+      text-decoration: none;
+      font-size: 0.875rem;
+    }
+
+    h1 {
+      font-size: 1.8rem;
+      color: #1f2937;
+      margin: 0.25rem 0 0;
+    }
+
+    .header-actions {
+      display: flex;
+      gap: 0.75rem;
+    }
+
+    .btn {
+      padding: 0.625rem 1.25rem;
+      border-radius: 0.5rem;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      transition: all 0.2s;
+    }
+
+    .btn-primary { background: #3b82f6; color: white; }
+    .btn-primary:hover { background: #2563eb; }
+    .btn-secondary { background: #e5e7eb; color: #374151; }
+    .btn-secondary:hover { background: #d1d5db; }
+    .btn-sm { padding: 0.375rem 0.75rem; font-size: 0.875rem; }
+
+    /* Filters */
+    .filters-container {
+      display: flex;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+      flex-wrap: wrap;
+    }
+
+    .filter-group {
+      display: flex;
+      flex-direction: column;
+      min-width: 150px;
+    }
+
+    .filter-group label {
+      font-size: 0.75rem;
+      color: #6b7280;
+      margin-bottom: 0.25rem;
+      font-weight: 500;
+    }
+
+    .filter-group input,
+    .filter-group select {
+      padding: 0.5rem;
+      border: 1px solid #d1d5db;
+      border-radius: 0.375rem;
+      font-size: 0.875rem;
+    }
+
+    /* Table */
+    .table-container {
+      background: white;
+      border-radius: 1rem;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+      overflow-x: auto;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    th, td {
+      padding: 0.875rem 1rem;
+      text-align: left;
+      border-bottom: 1px solid #e5e7eb;
+    }
+
+    th {
+      background: #f9fafb;
+      font-weight: 600;
+      color: #374151;
+      font-size: 0.875rem;
+    }
+
+    .expand-col {
+      width: 40px;
+      text-align: center;
+    }
+
+    .expand-icon {
+      color: #9ca3af;
+      font-size: 0.75rem;
+      cursor: pointer;
+    }
+
+    .balance-col {
+      text-align: center;
+      min-width: 140px;
+    }
+
+    .employee-row {
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+
+    .employee-row:hover {
+      background: #f9fafb;
+    }
+
+    .employee-row.expanded {
+      background: #eff6ff;
+    }
+
+    .balance-display {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .balance-available {
+      font-weight: 600;
+      font-size: 1rem;
+    }
+
+    .balance-used {
+      font-size: 0.75rem;
+      color: #9ca3af;
+    }
+
+    .no-balance {
+      color: #d1d5db;
+    }
+
+    /* Detail Row */
+    .detail-row td {
+      padding: 0;
+      background: #f9fafb;
+    }
+
+    .detail-container {
+      padding: 1.5rem;
+      background: white;
+      margin: 0.5rem;
+      border-radius: 0.5rem;
+      border: 1px solid #e5e7eb;
+    }
+
+    .detail-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 1rem;
+    }
+
+    .detail-header h3 {
+      margin: 0;
+      color: #1f2937;
+    }
+
+    .detail-info {
+      display: flex;
+      gap: 1.5rem;
+      color: #6b7280;
+      font-size: 0.875rem;
+    }
+
+    .balance-summary {
+      display: flex;
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+
+    .summary-card {
+      background: #f3f4f6;
+      padding: 0.75rem 1rem;
+      border-radius: 0.5rem;
+      display: flex;
+      flex-direction: column;
+      min-width: 100px;
+    }
+
+    .summary-card .label {
+      font-size: 0.75rem;
+      color: #6b7280;
+    }
+
+    .summary-card .value {
+      font-size: 1.25rem;
+      font-weight: 600;
+      color: #1f2937;
+    }
+
+    .summary-card .value.used {
+      color: #ef4444;
+    }
+
+    .summary-card.highlight {
+      background: #dbeafe;
+    }
+
+    .summary-card.highlight .value {
+      color: #1d4ed8;
+    }
+
+    /* Transactions Table */
+    .transactions-table {
+      margin-bottom: 1rem;
+    }
+
+    .transactions-table table {
+      font-size: 0.875rem;
+    }
+
+    .transactions-table th {
+      background: #f3f4f6;
+      font-size: 0.75rem;
+    }
+
+    .trans-type {
+      display: inline-block;
+      padding: 0.125rem 0.5rem;
+      border-radius: 0.25rem;
+      font-size: 0.75rem;
+      color: white;
+    }
+
+    .positive { color: #22c55e; font-weight: 600; }
+    .negative { color: #ef4444; font-weight: 600; }
+
+    .detail-actions {
+      display: flex;
+      justify-content: flex-end;
+    }
+
+    .empty-table, .empty-row {
+      text-align: center;
+      color: #9ca3af;
+      padding: 2rem !important;
+    }
+
+    /* Loading */
+    .loading-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(255, 255, 255, 0.8);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 100;
+    }
+
+    .spinner {
+      width: 40px;
+      height: 40px;
+      border: 3px solid #e5e7eb;
+      border-top-color: #3b82f6;
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+
+    /* Modals */
+    .modal-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0, 0, 0, 0.5);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 50;
+    }
+
+    .modal {
+      background: white;
+      padding: 2rem;
+      border-radius: 1rem;
+      width: 100%;
+      max-width: 500px;
+      max-height: 90vh;
+      overflow-y: auto;
+    }
+
+    .modal-wide {
+      max-width: 700px;
+    }
+
+    .modal h2 {
+      margin: 0 0 1.5rem;
+      color: #1f2937;
+    }
+
+    .form-group {
+      margin-bottom: 1rem;
+    }
+
+    .form-group label {
+      display: block;
+      margin-bottom: 0.5rem;
+      font-weight: 500;
+      color: #374151;
+    }
+
+    .form-group input,
+    .form-group select,
+    .form-group textarea {
+      width: 100%;
+      padding: 0.625rem;
+      border: 2px solid #e5e7eb;
+      border-radius: 0.5rem;
+      font-size: 1rem;
+      box-sizing: border-box;
+    }
+
+    .form-group input:focus,
+    .form-group select:focus,
+    .form-group textarea:focus {
+      outline: none;
+      border-color: #3b82f6;
+    }
+
+    .form-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+    }
+
+    .info-text {
+      background: #f3f4f6;
+      padding: 0.75rem;
+      border-radius: 0.5rem;
+      font-size: 0.875rem;
+      color: #6b7280;
+      margin-bottom: 1rem;
+    }
+
+    .modal-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 0.75rem;
+      margin-top: 1.5rem;
+    }
+
+    /* Policies List */
+    .policies-list {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .policy-card {
+      background: #f9fafb;
+      padding: 1rem;
+      border-radius: 0.5rem;
+      border-left: 4px solid;
+    }
+
+    .policy-header {
+      display: flex;
+      justify-content: space-between;
+      margin-bottom: 0.5rem;
+    }
+
+    .policy-name {
+      font-weight: 600;
+      color: #1f2937;
+    }
+
+    .policy-code {
+      font-size: 0.75rem;
+      color: #9ca3af;
+      font-family: monospace;
+    }
+
+    .policy-details {
+      display: flex;
+      gap: 1rem;
+      font-size: 0.875rem;
+      color: #6b7280;
+    }
+  `],
+})
+export class LeaveBalancesComponent implements OnInit {
+  private readonly leaveBalanceService = inject(LeaveBalanceService);
+  private readonly departmentService = inject(DepartmentService);
+  private readonly employeeService = inject(EmployeeService);
+
+  // Data
+  readonly policies = signal<LeavePolicy[]>([]);
+  readonly departments = signal<Department[]>([]);
+  readonly balanceSummaries = signal<EmployeeBalanceSummary[]>([]);
+  readonly expandedDetail = signal<EmployeeBalanceDetail | null>(null);
+
+  // UI State
+  readonly loading = signal(false);
+  readonly expandedEmployeeId = signal<string | null>(null);
+  readonly showBulkAccrualModal = signal(false);
+  readonly showPoliciesModal = signal(false);
+  readonly showTransactionModal = signal(false);
+
+  // Filters
+  filters = {
+    search: '',
+    policyId: '',
+    departmentId: '',
+    periodYear: new Date().getFullYear(),
+  };
+
+  private searchTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  // Bulk accrual form
+  bulkAccrual = {
+    policy_id: '',
+    period_year: new Date().getFullYear(),
+  };
+
+  // Transaction form
+  newTransaction = {
+    balance_id: '',
+    transaction_type: 'debit' as const,
+    amount: 0,
+    description: '',
+    usage_start_date: '',
+    usage_end_date: '',
+  };
+
+  // Computed
+  readonly availableYears = computed(() => {
+    const currentYear = new Date().getFullYear();
+    return [currentYear - 1, currentYear, currentYear + 1];
+  });
+
+  ngOnInit(): void {
+    this.loadInitialData();
+  }
+
+  loadInitialData(): void {
+    this.loading.set(true);
+
+    forkJoin({
+      policies: this.leaveBalanceService.getPolicies(),
+      departments: this.departmentService.getDepartments(),
+    }).subscribe({
+      next: ({ policies, departments }) => {
+        this.policies.set(policies);
+        this.departments.set(departments);
+        this.loadBalances();
+      },
+      error: (err) => {
+        console.error('Error loading initial data:', err);
+        this.loading.set(false);
+      },
+    });
+  }
+
+  loadBalances(): void {
+    this.loading.set(true);
+    this.expandedEmployeeId.set(null);
+    this.expandedDetail.set(null);
+
+    this.leaveBalanceService
+      .getBalances({
+        search: this.filters.search || undefined,
+        policy_id: this.filters.policyId || undefined,
+        department_id: this.filters.departmentId || undefined,
+        period_year: this.filters.periodYear,
+      })
+      .subscribe({
+        next: (data) => {
+          this.balanceSummaries.set(data);
+          this.loading.set(false);
+        },
+        error: (err) => {
+          console.error('Error loading balances:', err);
+          this.loading.set(false);
+        },
+      });
+  }
+
+  onSearchChange(): void {
+    if (this.searchTimeout) {
+      clearTimeout(this.searchTimeout);
+    }
+    this.searchTimeout = setTimeout(() => {
+      this.loadBalances();
+    }, 300);
+  }
+
+  // Expand/Collapse
+  isExpanded(employeeId: string): boolean {
+    return this.expandedEmployeeId() === employeeId;
+  }
+
+  toggleExpand(employee: EmployeeBalanceSummary): void {
+    if (this.isExpanded(employee.employee_id)) {
+      this.expandedEmployeeId.set(null);
+      this.expandedDetail.set(null);
+    } else {
+      // Find first balance with a policy
+      const firstBalance = employee.balances[0];
+      if (firstBalance) {
+        this.loadEmployeeDetail(employee.employee_id, firstBalance.policy_id);
+      }
+      this.expandedEmployeeId.set(employee.employee_id);
+    }
+  }
+
+  loadEmployeeDetail(employeeId: string, policyId: string): void {
+    this.leaveBalanceService
+      .getEmployeeBalanceDetail(employeeId, policyId, this.filters.periodYear)
+      .subscribe({
+        next: (detail) => {
+          this.expandedDetail.set(detail);
+        },
+        error: (err) => {
+          console.error('Error loading detail:', err);
+        },
+      });
+  }
+
+  // Helpers
+  getBalanceForPolicy(
+    employee: EmployeeBalanceSummary,
+    policyId: string
+  ): EmployeeBalanceSummary['balances'][0] | undefined {
+    return employee.balances.find((b) => b.policy_id === policyId);
+  }
+
+  formatBalanceValue(amount: number, unit: string | null): string {
+    return formatBalance(amount, (unit as 'days' | 'hours') || 'days');
+  }
+
+  getTransactionLabel(type: string): string {
+    return TRANSACTION_TYPE_LABELS[type as keyof typeof TRANSACTION_TYPE_LABELS] || type;
+  }
+
+  getTransactionColor(type: string): string {
+    return TRANSACTION_TYPE_COLORS[type as keyof typeof TRANSACTION_TYPE_COLORS] || '#6b7280';
+  }
+
+  getUnitLabel(unit: string): string {
+    return LEAVE_UNIT_LABELS[unit as keyof typeof LEAVE_UNIT_LABELS] || unit;
+  }
+
+  // Bulk Accrual Modal
+  openBulkAccrualModal(): void {
+    this.bulkAccrual = {
+      policy_id: '',
+      period_year: new Date().getFullYear(),
+    };
+    this.showBulkAccrualModal.set(true);
+  }
+
+  closeBulkAccrualModal(): void {
+    this.showBulkAccrualModal.set(false);
+  }
+
+  executeBulkAccrual(): void {
+    if (!this.bulkAccrual.policy_id) return;
+
+    this.loading.set(true);
+    this.leaveBalanceService
+      .bulkAccrual({
+        policy_id: this.bulkAccrual.policy_id,
+        period_year: this.bulkAccrual.period_year,
+      })
+      .subscribe({
+        next: (result) => {
+          alert(`Acreditacion completada: ${result.count} empleados procesados`);
+          this.closeBulkAccrualModal();
+          this.loadBalances();
+        },
+        error: (err) => {
+          console.error('Error in bulk accrual:', err);
+          alert(err.error?.detail || 'Error al ejecutar acreditacion masiva');
+          this.loading.set(false);
+        },
+      });
+  }
+
+  // Policies Modal
+  openPoliciesModal(): void {
+    this.showPoliciesModal.set(true);
+  }
+
+  closePoliciesModal(): void {
+    this.showPoliciesModal.set(false);
+  }
+
+  // Transaction Modal
+  openAddTransactionModal(): void {
+    const detail = this.expandedDetail();
+    if (!detail) return;
+
+    this.newTransaction = {
+      balance_id: detail.balance.id,
+      transaction_type: 'debit',
+      amount: 0,
+      description: '',
+      usage_start_date: '',
+      usage_end_date: '',
+    };
+    this.showTransactionModal.set(true);
+  }
+
+  closeTransactionModal(): void {
+    this.showTransactionModal.set(false);
+  }
+
+  saveTransaction(): void {
+    if (!this.newTransaction.balance_id || this.newTransaction.amount <= 0) return;
+
+    this.leaveBalanceService
+      .createTransaction({
+        balance_id: this.newTransaction.balance_id,
+        transaction_type: this.newTransaction.transaction_type,
+        amount: this.newTransaction.amount,
+        description: this.newTransaction.description || undefined,
+        usage_start_date: this.newTransaction.usage_start_date || undefined,
+        usage_end_date: this.newTransaction.usage_end_date || undefined,
+      })
+      .subscribe({
+        next: () => {
+          this.closeTransactionModal();
+          // Reload detail
+          const detail = this.expandedDetail();
+          if (detail) {
+            this.loadEmployeeDetail(detail.employee_id, detail.balance.policy_id);
+          }
+          this.loadBalances();
+        },
+        error: (err) => {
+          console.error('Error saving transaction:', err);
+          alert(err.error?.detail || 'Error al guardar movimiento');
+        },
+      });
+  }
+}

--- a/frontend/src/app/features/admin/pages/schedules/schedules.component.ts
+++ b/frontend/src/app/features/admin/pages/schedules/schedules.component.ts
@@ -1636,13 +1636,12 @@ export class SchedulesComponent implements OnInit {
 
     this.loadingAssignments.set(true);
 
-    // Check assignments for all selected employees in the date range
+    // Search ALL assignments for the employee (no date filter)
+    // This ensures we find assignments even if they're outside the visible calendar week
     const promises = employeeIds.map((empId) =>
       this.scheduleService
         .getAssignments({
           employee_id: empId,
-          date_from: this.assignForm.startDate,
-          date_to: this.assignForm.endDate,
         })
         .toPromise()
     );

--- a/frontend/src/app/features/admin/pages/schedules/schedules.component.ts
+++ b/frontend/src/app/features/admin/pages/schedules/schedules.component.ts
@@ -6,9 +6,11 @@ import { forkJoin, catchError, of } from 'rxjs';
 import { ScheduleService } from '../../../../core/services/schedule.service';
 import { EmployeeService } from '../../../../core/services/employee.service';
 import { DepartmentService } from '../../../../core/services/department.service';
+import { ToastService } from '../../../../core/services/toast.service';
 import {
   SchedulePattern,
   SchedulePatternCreate,
+  ScheduleAssignment,
   CalendarEmployee,
   CalendarDay,
   CalendarFilters,
@@ -223,7 +225,7 @@ interface WeekDay {
         <section class="bulk-actions">
           <span class="selected-count">{{ selectedEmployees().length }} empleado(s) seleccionado(s)</span>
           <div class="bulk-buttons">
-            <button class="btn btn-secondary" (click)="showAssignModal.set(true)">
+            <button class="btn btn-secondary" (click)="openAssignModal()">
               Asignar Horario
             </button>
             <button class="btn btn-warning" (click)="showExceptionModal.set(true)">
@@ -311,13 +313,25 @@ interface WeekDay {
         <div class="modal-overlay" (click)="closeAssignModal()">
           <div class="modal" (click)="$event.stopPropagation()">
             <div class="modal-header">
-              <h2>Asignar Horario</h2>
+              <h2>{{ existingAssignmentsCount() > 0 ? 'Editar Asignacion' : 'Asignar Horario' }}</h2>
               <button class="close-btn" (click)="closeAssignModal()">&#10005;</button>
             </div>
             <div class="modal-body">
               <p class="modal-info">
-                Asignando horario a <strong>{{ selectedEmployees().length }}</strong> empleado(s)
+                {{ existingAssignmentsCount() > 0 ? 'Editando' : 'Asignando' }} horario a <strong>{{ selectedEmployees().length }}</strong> empleado(s)
               </p>
+
+              @if (loadingAssignments()) {
+                <div class="loading-info">
+                  <span class="spinner-small"></span> Verificando asignaciones existentes...
+                </div>
+              } @else if (existingAssignmentsCount() > 0) {
+                <div class="existing-warning">
+                  <span class="warning-icon">&#9888;</span>
+                  <span>Se encontraron <strong>{{ existingAssignmentsCount() }}</strong> asignaciones existentes en este rango. Se actualizaran con los nuevos valores.</span>
+                </div>
+              }
+
               <div class="form-grid">
                 <div class="form-group">
                   <label for="assignPattern">Patron de Horario</label>
@@ -1088,6 +1102,48 @@ interface WeekDay {
       cursor: pointer;
     }
 
+    /* Loading & Warning */
+    .loading-info {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.75rem 1rem;
+      background: #f3f4f6;
+      border-radius: 0.5rem;
+      margin-bottom: 1rem;
+      color: #6b7280;
+      font-size: 0.875rem;
+    }
+
+    .spinner-small {
+      width: 1rem;
+      height: 1rem;
+      border: 2px solid #e5e7eb;
+      border-top-color: #6366f1;
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+
+    .existing-warning {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.75rem;
+      padding: 0.875rem 1rem;
+      background: #fef3c7;
+      border: 1px solid #f59e0b;
+      border-radius: 0.5rem;
+      margin-bottom: 1rem;
+      color: #92400e;
+      font-size: 0.875rem;
+      line-height: 1.4;
+    }
+
+    .warning-icon {
+      font-size: 1.25rem;
+      flex-shrink: 0;
+      color: #f59e0b;
+    }
+
     /* Responsive */
     @media (max-width: 1200px) {
       .filters-grid {
@@ -1148,6 +1204,7 @@ export class SchedulesComponent implements OnInit {
   private readonly scheduleService = inject(ScheduleService);
   private readonly employeeService = inject(EmployeeService);
   private readonly departmentService = inject(DepartmentService);
+  private readonly toast = inject(ToastService);
 
   // State signals
   readonly calendar = signal<CalendarEmployee[]>([]);
@@ -1164,6 +1221,8 @@ export class SchedulesComponent implements OnInit {
   readonly showExceptionModal = signal(false);
   readonly editingPattern = signal<SchedulePattern | null>(null);
   readonly exceptionModalMode = signal<'new' | 'bulk'>('bulk');
+  readonly existingAssignmentsCount = signal(0);
+  readonly loadingAssignments = signal(false);
 
   // Filters
   filters: CalendarFilters = {
@@ -1511,18 +1570,26 @@ export class SchedulesComponent implements OnInit {
     if (editing) {
       this.scheduleService.updatePattern(editing.id, data).subscribe({
         next: () => {
+          this.toast.success('Patron actualizado');
           this.loadPatterns();
           this.cancelEditPattern();
         },
-        error: (err) => console.error('Error updating pattern:', err),
+        error: (err) => {
+          console.error('Error updating pattern:', err);
+          this.toast.error('Error al actualizar el patron');
+        },
       });
     } else {
       this.scheduleService.createPattern(data).subscribe({
         next: () => {
+          this.toast.success('Patron creado exitosamente');
           this.loadPatterns();
           this.patternForm = this.getEmptyPatternForm();
         },
-        error: (err) => console.error('Error creating pattern:', err),
+        error: (err) => {
+          console.error('Error creating pattern:', err);
+          this.toast.error('Error al crear el patron');
+        },
       });
     }
   }
@@ -1530,8 +1597,14 @@ export class SchedulesComponent implements OnInit {
   deletePattern(id: string): void {
     if (confirm('Esta seguro de eliminar este patron?')) {
       this.scheduleService.deletePattern(id).subscribe({
-        next: () => this.loadPatterns(),
-        error: (err) => console.error('Error deleting pattern:', err),
+        next: () => {
+          this.toast.success('Patron eliminado');
+          this.loadPatterns();
+        },
+        error: (err) => {
+          console.error('Error deleting pattern:', err);
+          this.toast.error('Error al eliminar el patron');
+        },
       });
     }
   }
@@ -1544,9 +1617,47 @@ export class SchedulesComponent implements OnInit {
   }
 
   // Assign Modal
+  openAssignModal(): void {
+    this.assignForm = this.getEmptyAssignForm();
+    this.existingAssignmentsCount.set(0);
+    this.showAssignModal.set(true);
+    this.checkExistingAssignments();
+  }
+
   closeAssignModal(): void {
     this.showAssignModal.set(false);
+    this.existingAssignmentsCount.set(0);
     this.assignForm = this.getEmptyAssignForm();
+  }
+
+  private checkExistingAssignments(): void {
+    const employeeIds = this.selectedEmployees();
+    if (employeeIds.length === 0) return;
+
+    this.loadingAssignments.set(true);
+
+    // Check assignments for all selected employees in the date range
+    const promises = employeeIds.map((empId) =>
+      this.scheduleService
+        .getAssignments({
+          employee_id: empId,
+          date_from: this.assignForm.startDate,
+          date_to: this.assignForm.endDate,
+        })
+        .toPromise()
+    );
+
+    Promise.all(promises)
+      .then((results) => {
+        // Count total existing assignments
+        const totalCount = results.reduce((sum, assignments) => sum + (assignments?.length || 0), 0);
+        this.existingAssignmentsCount.set(totalCount);
+        this.loadingAssignments.set(false);
+      })
+      .catch((err) => {
+        console.error('Error checking existing assignments:', err);
+        this.loadingAssignments.set(false);
+      });
   }
 
   toggleWeekday(day: number): void {
@@ -1569,13 +1680,20 @@ export class SchedulesComponent implements OnInit {
     };
 
     this.scheduleService.createBulkAssignments(bulk).subscribe({
-      next: (result) => {
-        console.log('Assignments created:', result);
+      next: (result: { created: number; updated: number }) => {
+        const total = result.created + result.updated;
+        const message = result.updated > 0
+          ? `Asignaciones guardadas: ${result.created} creadas, ${result.updated} actualizadas`
+          : `${result.created} asignaciones creadas exitosamente`;
+        this.toast.success(message);
         this.closeAssignModal();
         this.clearSelection();
         this.loadCalendar();
       },
-      error: (err) => console.error('Error creating assignments:', err),
+      error: (err) => {
+        console.error('Error creating assignments:', err);
+        this.toast.error('Error al crear las asignaciones');
+      },
     });
   }
 
@@ -1629,13 +1747,18 @@ export class SchedulesComponent implements OnInit {
 
     Promise.all(promises)
       .then(() => {
+        const count = employeeIds.length;
+        this.toast.success(count > 1 ? `${count} excepciones creadas` : 'Excepcion creada exitosamente');
         this.closeExceptionModal();
         if (mode === 'bulk') {
           this.clearSelection();
         }
         this.loadCalendar();
       })
-      .catch((err) => console.error('Error creating exceptions:', err));
+      .catch((err) => {
+        console.error('Error creating exceptions:', err);
+        this.toast.error('Error al crear las excepciones');
+      });
   }
 
   // Export

--- a/frontend/src/app/shared/components/toast/toast.component.ts
+++ b/frontend/src/app/shared/components/toast/toast.component.ts
@@ -1,0 +1,128 @@
+import { Component, inject } from '@angular/core';
+import { ToastService, Toast } from '../../../core/services/toast.service';
+
+@Component({
+  selector: 'app-toast',
+  standalone: true,
+  template: `
+    <div class="toast-container">
+      @for (toast of toastService.toasts(); track toast.id) {
+        <div class="toast" [class]="'toast-' + toast.type" (click)="toastService.dismiss(toast.id)">
+          <span class="toast-icon">{{ getIcon(toast.type) }}</span>
+          <span class="toast-message">{{ toast.message }}</span>
+          <button class="toast-close" (click)="toastService.dismiss(toast.id); $event.stopPropagation()">
+            &times;
+          </button>
+        </div>
+      }
+    </div>
+  `,
+  styles: [`
+    .toast-container {
+      position: fixed;
+      top: 1rem;
+      right: 1rem;
+      z-index: 9999;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      max-width: 400px;
+    }
+
+    .toast {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.875rem 1rem;
+      border-radius: 0.5rem;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+      cursor: pointer;
+      animation: slideIn 0.3s ease-out;
+      min-width: 280px;
+    }
+
+    @keyframes slideIn {
+      from {
+        transform: translateX(100%);
+        opacity: 0;
+      }
+      to {
+        transform: translateX(0);
+        opacity: 1;
+      }
+    }
+
+    .toast-success {
+      background: #059669;
+      color: white;
+    }
+
+    .toast-error {
+      background: #dc2626;
+      color: white;
+    }
+
+    .toast-warning {
+      background: #f59e0b;
+      color: white;
+    }
+
+    .toast-info {
+      background: #3b82f6;
+      color: white;
+    }
+
+    .toast-icon {
+      font-size: 1.25rem;
+      flex-shrink: 0;
+    }
+
+    .toast-message {
+      flex: 1;
+      font-size: 0.875rem;
+      font-weight: 500;
+      line-height: 1.4;
+    }
+
+    .toast-close {
+      background: transparent;
+      border: none;
+      color: inherit;
+      font-size: 1.25rem;
+      cursor: pointer;
+      opacity: 0.7;
+      padding: 0;
+      line-height: 1;
+      flex-shrink: 0;
+    }
+
+    .toast-close:hover {
+      opacity: 1;
+    }
+
+    @media (max-width: 480px) {
+      .toast-container {
+        left: 1rem;
+        right: 1rem;
+        max-width: none;
+      }
+
+      .toast {
+        min-width: auto;
+      }
+    }
+  `],
+})
+export class ToastComponent {
+  readonly toastService = inject(ToastService);
+
+  getIcon(type: string): string {
+    const icons: Record<string, string> = {
+      success: '\u2713',
+      error: '\u2717',
+      warning: '\u26A0',
+      info: '\u2139',
+    };
+    return icons[type] || '\u2139';
+  }
+}


### PR DESCRIPTION
## Summary

Implementación completa del módulo de **Saldos Laborales** inspirado en SIA.red.

### Backend (FastAPI + SQLAlchemy)
- **LeavePolicy**: Políticas configurables de saldos (vacaciones, incapacidad, compensatorio)
- **LeaveBalance**: Saldos por empleado/tipo/periodo
- **LeaveTransaction**: Historial de movimientos (acreditaciones, descuentos, ajustes)
- **LeaveService**: Lógica de cálculo automático de vacaciones según antigüedad
- Endpoints CRUD completos + acreditación masiva

### Frontend (Angular 19)
- Componente standalone con signals
- Tabla expandible estilo SIA
- Filtros: búsqueda, tipo, departamento, periodo
- Modal de acreditación masiva
- Modal de transacciones manuales
- Modal de visualización de políticas

### Cálculo automático de vacaciones
- Base: 15 días/año
- Incremento: +1 día cada 5 años de antigüedad
- Tope máximo: 30 días

## Test plan
- [ ] Verificar vista `/admin/leave-balances` carga correctamente
- [ ] Verificar filtros funcionan (búsqueda, tipo, departamento)
- [ ] Expandir empleado y ver historial de transacciones
- [ ] Probar acreditación masiva de saldos
- [ ] Probar agregar transacción manual
- [ ] Verificar políticas se muestran correctamente

## Screenshots
Basado en capturas de SIA.red proporcionadas por el usuario.