### PR TITLE
docs: add OpenAPI/Swagger documentation to all 51 endpoints

### DIFF
--- a/backend/app/api/v1/endpoints/attendance.py
+++ b/backend/app/api/v1/endpoints/attendance.py
@@ -62,11 +62,36 @@ async def _validate_geo(
     return validation.is_valid, validation.distance_meters
 
 
-@router.post("/check-in", response_model=AttendanceResponse)
+@router.post(
+    "/check-in",
+    response_model=AttendanceResponse,
+    tags=["attendance"],
+    responses={
+        400: {"description": "No se detectó rostro en la imagen o error al procesarla"},
+        404: {"description": "Ningún empleado coincide con el rostro enviado"},
+        422: {"description": "Error de validación — coordenadas inválidas o imágenes faltantes"},
+    },
+)
 async def check_in(
     db: Annotated[AsyncSession, Depends(get_db)],
     request: AttendanceCheckIn,
 ) -> AttendanceResponse:
+    """
+    Registrar entrada de un catedrático por reconocimiento facial.
+
+    No requiere autenticación. El rostro en las imágenes es la credencial.
+
+    **Proceso interno:**
+    1. Extrae el embedding facial de `images[0]` usando dlib (face_recognition)
+    2. Busca el empleado más parecido en la DB con pgvector (distancia coseno)
+    3. Si la distancia supera el umbral (0.6), devuelve 404
+    4. Valida geolocalización contra la sede asignada al empleado (Haversine)
+    5. Registra la entrada con hora, confianza facial y resultado GPS
+
+    **Nota:** Si el empleado ya tiene check-in hoy, devuelve el registro existente
+    con `message` indicando la hora del check-in previo. La geolocalización es
+    **opcional** — su ausencia o fallo no bloquea el registro.
+    """
     face_service = FaceRecognitionService()
 
     # Get embedding from first image in the array
@@ -169,11 +194,35 @@ async def check_in(
     )
 
 
-@router.post("/check-out", response_model=AttendanceResponse)
+@router.post(
+    "/check-out",
+    response_model=AttendanceResponse,
+    tags=["attendance"],
+    responses={
+        400: {"description": "No se detectó rostro, error de imagen, o no existe check-in previo para hoy"},
+        404: {"description": "Ningún empleado coincide con el rostro enviado"},
+        422: {"description": "Error de validación — coordenadas inválidas o imágenes faltantes"},
+    },
+)
 async def check_out(
     db: Annotated[AsyncSession, Depends(get_db)],
     request: AttendanceCheckOut,
 ) -> AttendanceResponse:
+    """
+    Registrar salida de un catedrático por reconocimiento facial.
+
+    No requiere autenticación. El rostro en las imágenes es la credencial.
+
+    **Proceso interno:**
+    1. Identifica al empleado por reconocimiento facial (igual que check-in)
+    2. Busca el registro de asistencia de hoy para ese empleado
+    3. Si no existe check-in previo, devuelve 400
+    4. Valida geolocalización y registra la salida con hora y confianza
+    5. `geo_validated` se mantiene `true` solo si tanto check-in como check-out fueron válidos
+
+    **Nota:** Si el empleado ya tiene check-out hoy, devuelve el registro existente
+    con `message` indicando la hora del check-out previo.
+    """
     face_service = FaceRecognitionService()
 
     try:
@@ -275,7 +324,14 @@ async def check_out(
     )
 
 
-@router.get("/", response_model=list[AttendanceResponse])
+@router.get(
+    "/",
+    response_model=list[AttendanceResponse],
+    tags=["attendance"],
+    responses={
+        401: {"description": "Token inválido o expirado — se requiere rol admin"},
+    },
+)
 async def list_attendance(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
@@ -287,6 +343,18 @@ async def list_attendance(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
 ) -> list[AttendanceResponse]:
+    """
+    Listar registros de asistencia con filtros opcionales. Requiere rol admin.
+
+    **Filtros disponibles (todos opcionales, combinables):**
+    - `record_date` — fecha exacta (YYYY-MM-DD)
+    - `date_from` / `date_to` — rango de fechas (inclusive en ambos extremos)
+    - `employee_id` — UUID del empleado
+    - `status` — estado del registro (`present`, `absent`, `late`)
+
+    **Paginación:** usar `skip` y `limit` (máx. 1000 por request).
+    Los resultados se ordenan por fecha descendente.
+    """
     query = select(AttendanceRecord).options(selectinload(AttendanceRecord.employee))
 
     # Single date filter (backwards compatible)
@@ -326,11 +394,25 @@ async def list_attendance(
     ]
 
 
-@router.get("/today", response_model=list[AttendanceResponse])
+@router.get(
+    "/today",
+    response_model=list[AttendanceResponse],
+    tags=["attendance"],
+    responses={
+        401: {"description": "Token inválido o expirado — se requiere rol admin"},
+    },
+)
 async def list_today_attendance(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
 ) -> list[AttendanceResponse]:
+    """
+    Listar todos los registros de asistencia del día de hoy. Requiere rol admin.
+
+    Shortcut de `GET /` filtrado por la fecha actual del servidor.
+    Los resultados se ordenan por hora de check-in descendente (el más reciente primero).
+    Útil para el dashboard en tiempo real y el kiosk de supervisión.
+    """
     today = date.today()
 
     query = (

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -19,11 +19,32 @@ from app.schemas.user import Token, UserCreate, UserResponse
 router = APIRouter()
 
 
-@router.post("/login", response_model=Token)
+@router.post(
+    "/login",
+    response_model=Token,
+    tags=["auth"],
+    responses={
+        401: {"description": "Email o contraseña incorrectos"},
+        403: {"description": "Usuario inactivo — cuenta deshabilitada"},
+    },
+)
 async def login(
     db: Annotated[AsyncSession, Depends(get_db)],
     form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
 ) -> Token:
+    """
+    Autenticar un usuario y obtener tokens JWT.
+
+    **Formato del request:** `application/x-www-form-urlencoded` (NO JSON).
+    Usar los campos `username` (email) y `password`.
+
+    En Swagger UI: click en **Authorize** arriba a la derecha, ingresar email y password.
+    En Postman/Insomnia: body tipo `form-data` o `x-www-form-urlencoded`.
+
+    **Respuesta:**
+    - `access_token` — válido por 30 minutos. Usar en el header `Authorization: Bearer <token>`
+    - `refresh_token` — válido por 7 días. Usar en `POST /refresh` para renovar el access token
+    """
     result = await db.execute(select(User).where(User.email == form_data.username))
     user = result.scalar_one_or_none()
 
@@ -46,11 +67,29 @@ async def login(
     )
 
 
-@router.post("/register", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/register",
+    response_model=UserResponse,
+    status_code=status.HTTP_201_CREATED,
+    tags=["auth"],
+    responses={
+        400: {"description": "El email ya está registrado"},
+    },
+)
 async def register(
     db: Annotated[AsyncSession, Depends(get_db)],
     user_in: UserCreate,
 ) -> User:
+    """
+    Registrar un nuevo usuario administrador del sistema.
+
+    Este endpoint crea usuarios con acceso al panel de administración.
+    No confundir con el registro de empleados (`POST /employees/`) —
+    los empleados son las personas cuya asistencia se controla,
+    los usuarios son quienes administran el sistema.
+
+    El email debe ser único. La contraseña se hashea con bcrypt antes de guardarse.
+    """
     result = await db.execute(select(User).where(User.email == user_in.email))
     existing_user = result.scalar_one_or_none()
 
@@ -74,11 +113,28 @@ async def register(
     return user
 
 
-@router.post("/refresh", response_model=Token)
+@router.post(
+    "/refresh",
+    response_model=Token,
+    tags=["auth"],
+    responses={
+        401: {"description": "Refresh token inválido, expirado o usuario inactivo"},
+    },
+)
 async def refresh_token(
     db: Annotated[AsyncSession, Depends(get_db)],
     refresh_token: str,
 ) -> Token:
+    """
+    Renovar el access token usando un refresh token válido.
+
+    El access token expira en 30 minutos. Cuando recibas un 401 en cualquier
+    endpoint protegido, usá este endpoint con el `refresh_token` obtenido en el login
+    para obtener un nuevo par de tokens sin pedir las credenciales de nuevo.
+
+    El refresh token expira en 7 días. Si también está expirado, el usuario debe
+    volver a hacer login.
+    """
     payload = decode_token(refresh_token)
 
     if payload is None or payload.get("type") != "refresh":
@@ -103,8 +159,22 @@ async def refresh_token(
     )
 
 
-@router.get("/me", response_model=UserResponse)
+@router.get(
+    "/me",
+    response_model=UserResponse,
+    tags=["auth"],
+    responses={
+        401: {"description": "Token inválido o expirado"},
+    },
+)
 async def get_current_user_info(
     current_user: Annotated[User, Depends(get_current_user)],
 ) -> User:
+    """
+    Obtener los datos del usuario autenticado actualmente.
+
+    Útil para verificar que el token es válido y conocer el rol del usuario
+    sin hacer otra llamada. También sirve como health-check de autenticación
+    desde el frontend al cargar la aplicación.
+    """
     return current_user

--- a/backend/app/api/v1/endpoints/departments.py
+++ b/backend/app/api/v1/endpoints/departments.py
@@ -13,14 +13,18 @@ from app.schemas.department import DepartmentCreate, DepartmentUpdate, Departmen
 router = APIRouter()
 
 
-@router.get("/", response_model=list[DepartmentResponse])
+@router.get(
+    "/",
+    response_model=list[DepartmentResponse],
+    tags=["departments"],
+)
 async def list_departments(
     db: Annotated[AsyncSession, Depends(get_db)],
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
     active_only: bool = True,
 ) -> list[Department]:
-    """List all departments."""
+    """Listar facultades y departamentos. No requiere autenticación."""
     query = select(Department)
 
     if active_only:
@@ -32,12 +36,19 @@ async def list_departments(
     return result.scalars().all()
 
 
-@router.get("/{department_id}", response_model=DepartmentResponse)
+@router.get(
+    "/{department_id}",
+    response_model=DepartmentResponse,
+    tags=["departments"],
+    responses={
+        404: {"description": "Departamento no encontrado"},
+    },
+)
 async def get_department(
     db: Annotated[AsyncSession, Depends(get_db)],
     department_id: UUID,
 ) -> Department:
-    """Get a specific department."""
+    """Obtener un departamento por su UUID."""
     result = await db.execute(select(Department).where(Department.id == department_id))
     department = result.scalar_one_or_none()
 
@@ -50,13 +61,18 @@ async def get_department(
     return department
 
 
-@router.post("/", response_model=DepartmentResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/",
+    response_model=DepartmentResponse,
+    status_code=status.HTTP_201_CREATED,
+    tags=["departments"],
+)
 async def create_department(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     department_in: DepartmentCreate,
 ) -> Department:
-    """Create a new department (admin only)."""
+    """Crear un nuevo departamento o facultad. Requiere rol admin."""
     department = Department(**department_in.model_dump())
     db.add(department)
     await db.commit()
@@ -64,14 +80,21 @@ async def create_department(
     return department
 
 
-@router.patch("/{department_id}", response_model=DepartmentResponse)
+@router.patch(
+    "/{department_id}",
+    response_model=DepartmentResponse,
+    tags=["departments"],
+    responses={
+        404: {"description": "Departamento no encontrado"},
+    },
+)
 async def update_department(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     department_id: UUID,
     department_in: DepartmentUpdate,
 ) -> Department:
-    """Update a department (admin only)."""
+    """Actualizar un departamento parcialmente. Requiere rol admin."""
     result = await db.execute(select(Department).where(Department.id == department_id))
     department = result.scalar_one_or_none()
 
@@ -90,13 +113,20 @@ async def update_department(
     return department
 
 
-@router.delete("/{department_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{department_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    tags=["departments"],
+    responses={
+        404: {"description": "Departamento no encontrado"},
+    },
+)
 async def delete_department(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     department_id: UUID,
 ) -> None:
-    """Delete a department (admin only)."""
+    """Eliminar un departamento. Requiere rol admin."""
     result = await db.execute(select(Department).where(Department.id == department_id))
     department = result.scalar_one_or_none()
 

--- a/backend/app/api/v1/endpoints/employees.py
+++ b/backend/app/api/v1/endpoints/employees.py
@@ -14,7 +14,14 @@ from app.schemas.employee import EmployeeCreate, EmployeeUpdate, EmployeeRespons
 router = APIRouter()
 
 
-@router.get("/", response_model=list[EmployeeResponse])
+@router.get(
+    "/",
+    response_model=list[EmployeeResponse],
+    tags=["employees"],
+    responses={
+        401: {"description": "Token inválido o expirado — se requiere rol admin"},
+    },
+)
 async def list_employees(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
@@ -22,6 +29,18 @@ async def list_employees(
     limit: int = Query(100, ge=1, le=1000),
     active_only: bool = True,
 ) -> list[EmployeeResponse]:
+    """
+    Listar empleados/catedráticos registrados en el sistema. Requiere rol admin.
+
+    **Paginación:** usar `skip` y `limit` (máx. 1000 por request).
+    Los resultados se ordenan alfabéticamente por apellido y nombre.
+
+    **Filtro `active_only`:** por defecto `true` — solo devuelve empleados activos.
+    Pasar `active_only=false` para incluir empleados dados de baja.
+
+    El campo `has_face_registered` indica si el empleado ya tiene embeddings
+    faciales registrados y puede hacer check-in biométrico.
+    """
     query = select(Employee).options(selectinload(Employee.face_embeddings))
 
     if active_only:
@@ -54,12 +73,26 @@ async def list_employees(
     return response
 
 
-@router.get("/{employee_id}", response_model=EmployeeResponse)
+@router.get(
+    "/{employee_id}",
+    response_model=EmployeeResponse,
+    tags=["employees"],
+    responses={
+        401: {"description": "Token inválido o expirado — se requiere rol admin"},
+        404: {"description": "Empleado no encontrado"},
+    },
+)
 async def get_employee(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     employee_id: UUID,
 ) -> EmployeeResponse:
+    """
+    Obtener los datos de un empleado por su UUID. Requiere rol admin.
+
+    Incluye el estado de registro facial (`has_face_registered`) y las referencias
+    a departamento, puesto y sede asignados.
+    """
     query = (
         select(Employee)
         .options(selectinload(Employee.face_embeddings))
@@ -91,12 +124,30 @@ async def get_employee(
     )
 
 
-@router.post("/", response_model=EmployeeResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/",
+    response_model=EmployeeResponse,
+    status_code=status.HTTP_201_CREATED,
+    tags=["employees"],
+    responses={
+        400: {"description": "El `employee_code` ya existe — debe ser único en el sistema"},
+        401: {"description": "Token inválido o expirado — se requiere rol admin"},
+    },
+)
 async def create_employee(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     employee_in: EmployeeCreate,
 ) -> EmployeeResponse:
+    """
+    Crear un nuevo empleado/catedrático. Requiere rol admin.
+
+    El `employee_code` debe ser único (p.ej. `EMP-001`, número de carné, código institucional).
+    El email también es requerido y se usa solo para identificación interna — no se envían correos.
+
+    Después de crear el empleado, registrar sus fotos con `POST /faces/register`
+    para que pueda hacer check-in biométrico. Hasta entonces, `has_face_registered` es `false`.
+    """
     # Check if employee code already exists
     result = await db.execute(
         select(Employee).where(Employee.employee_code == employee_in.employee_code)
@@ -129,13 +180,30 @@ async def create_employee(
     )
 
 
-@router.patch("/{employee_id}", response_model=EmployeeResponse)
+@router.patch(
+    "/{employee_id}",
+    response_model=EmployeeResponse,
+    tags=["employees"],
+    responses={
+        401: {"description": "Token inválido o expirado — se requiere rol admin"},
+        404: {"description": "Empleado no encontrado"},
+    },
+)
 async def update_employee(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     employee_id: UUID,
     employee_in: EmployeeUpdate,
 ) -> EmployeeResponse:
+    """
+    Actualizar parcialmente los datos de un empleado. Requiere rol admin.
+
+    Solo se actualizan los campos incluidos en el body (PATCH semántico).
+    Para dar de baja a un empleado sin eliminarlo, usar `is_active: false`.
+
+    No modifica los embeddings faciales — para eso usar `DELETE /faces/{id}`
+    seguido de `POST /faces/register`.
+    """
     query = (
         select(Employee)
         .options(selectinload(Employee.face_embeddings))
@@ -174,12 +242,29 @@ async def update_employee(
     )
 
 
-@router.delete("/{employee_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{employee_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    tags=["employees"],
+    responses={
+        401: {"description": "Token inválido o expirado — se requiere rol admin"},
+        404: {"description": "Empleado no encontrado"},
+    },
+)
 async def delete_employee(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     employee_id: UUID,
 ) -> None:
+    """
+    Eliminar permanentemente un empleado y todos sus datos. Requiere rol admin.
+
+    **ADVERTENCIA — efecto CASCADE:** elimina también todos los registros asociados:
+    embeddings faciales, registros de asistencia e historial de sesiones biométricas.
+    Esta acción es irreversible.
+
+    Para desactivar sin perder historial, preferir `PATCH /{id}` con `is_active: false`.
+    """
     result = await db.execute(select(Employee).where(Employee.id == employee_id))
     employee = result.scalar_one_or_none()
 

--- a/backend/app/api/v1/endpoints/faces.py
+++ b/backend/app/api/v1/endpoints/faces.py
@@ -40,12 +40,38 @@ def _calculate_liveness_delta(metrics: StageMetrics | None) -> Decimal | None:
     )
 
 
-@router.post("/register", response_model=dict)
+@router.post(
+    "/register",
+    response_model=dict,
+    tags=["faces"],
+    responses={
+        400: {"description": "No se detectó rostro válido en ninguna de las imágenes"},
+        404: {"description": "El empleado no existe"},
+    },
+)
 async def register_face(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     request: FaceRegisterRequest,
 ) -> dict:
+    """
+    Registrar el embedding facial de un empleado. Requiere rol admin.
+
+    **Proceso interno:**
+    1. Verifica que el empleado exista en la DB
+    2. Procesa cada imagen con dlib para extraer embeddings de 128 dimensiones
+    3. Elimina los embeddings anteriores del empleado (si los había)
+    4. Guarda los nuevos embeddings en PostgreSQL (pgvector)
+    5. El primer embedding (`is_primary=True`) se usa como referencia principal
+
+    **Recomendaciones para mejor precisión:**
+    - Enviar 3–5 fotos con distintos ángulos (frontal, leve perfil izquierdo/derecho)
+    - Buena iluminación uniforme, sin sombras fuertes
+    - Resolución mínima 200×200 px por imagen
+
+    **Nota:** El registro reemplaza todos los embeddings previos del empleado.
+    Después de registrar, el campo `has_face_registered` del empleado pasa a `true`.
+    """
     # Verify employee exists
     result = await db.execute(
         select(Employee).where(Employee.id == request.employee_id)
@@ -185,11 +211,29 @@ async def register_face(
     }
 
 
-@router.post("/verify", response_model=FaceVerifyResponse)
+@router.post(
+    "/verify",
+    response_model=FaceVerifyResponse,
+    tags=["faces"],
+    responses={
+        200: {"description": "Verificación completada — `success: true` si hay match, `false` si no"},
+    },
+)
 async def verify_face(
     db: Annotated[AsyncSession, Depends(get_db)],
     request: FaceVerifyRequest,
 ) -> FaceVerifyResponse:
+    """
+    Verificar a qué empleado pertenece un rostro. No requiere autenticación.
+
+    A diferencia de check-in/check-out, este endpoint **no registra asistencia** —
+    solo identifica al empleado y devuelve su nombre y nivel de confianza.
+    Útil para diagnóstico y pruebas del sistema de reconocimiento facial.
+
+    **Respuesta:** Siempre devuelve 200. El campo `success` indica si hubo match:
+    - `success: true` → empleado identificado, incluye `employee_id`, `employee_name` y `confidence`
+    - `success: false` → sin match o imagen inválida, incluye `message` con el motivo
+    """
     face_service = FaceRecognitionService()
 
     # Get embedding from provided image
@@ -227,12 +271,27 @@ async def verify_face(
     )
 
 
-@router.delete("/{employee_id}")
+@router.delete(
+    "/{employee_id}",
+    tags=["faces"],
+    responses={
+        404: {"description": "El empleado no tiene embeddings registrados"},
+    },
+)
 async def delete_face_embeddings(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     employee_id: UUID,
 ) -> dict:
+    """
+    Eliminar todos los embeddings faciales de un empleado. Requiere rol admin.
+
+    Después de eliminar, el campo `has_face_registered` del empleado pasa a `false`
+    y no podrá hacer check-in/check-out hasta que se registren nuevos embeddings.
+
+    Útil para: re-registrar con mejores fotos, dar de baja a un empleado,
+    o corregir un registro incorrecto.
+    """
     result = await db.execute(
         select(FaceEmbedding).where(FaceEmbedding.employee_id == employee_id)
     )

--- a/backend/app/api/v1/endpoints/locations.py
+++ b/backend/app/api/v1/endpoints/locations.py
@@ -13,14 +13,18 @@ from app.schemas.location import LocationCreate, LocationUpdate, LocationRespons
 router = APIRouter()
 
 
-@router.get("/", response_model=list[LocationResponse])
+@router.get(
+    "/",
+    response_model=list[LocationResponse],
+    tags=["locations"],
+)
 async def list_locations(
     db: Annotated[AsyncSession, Depends(get_db)],
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
     active_only: bool = True,
 ) -> list[Location]:
-    """List all locations (sedes)."""
+    """Listar sedes de trabajo con sus coordenadas GPS y radio de validación."""
     query = select(Location)
 
     if active_only:
@@ -32,12 +36,19 @@ async def list_locations(
     return result.scalars().all()
 
 
-@router.get("/{location_id}", response_model=LocationResponse)
+@router.get(
+    "/{location_id}",
+    response_model=LocationResponse,
+    tags=["locations"],
+    responses={
+        404: {"description": "Sede no encontrada"},
+    },
+)
 async def get_location(
     db: Annotated[AsyncSession, Depends(get_db)],
     location_id: UUID,
 ) -> Location:
-    """Get a specific location."""
+    """Obtener una sede por su UUID. Incluye coordenadas y radio de validación GPS."""
     result = await db.execute(select(Location).where(Location.id == location_id))
     location = result.scalar_one_or_none()
 
@@ -50,13 +61,24 @@ async def get_location(
     return location
 
 
-@router.post("/", response_model=LocationResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/",
+    response_model=LocationResponse,
+    status_code=status.HTTP_201_CREATED,
+    tags=["locations"],
+)
 async def create_location(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     location_in: LocationCreate,
 ) -> Location:
-    """Create a new location (admin only)."""
+    """
+    Crear una nueva sede de trabajo. Requiere rol admin.
+
+    El `radius_meters` define el radio en metros alrededor de las coordenadas GPS
+    dentro del cual se considera válida la geolocalización de un empleado al hacer
+    check-in. Valor por defecto: 50 m. Rango válido: 10–5000 m.
+    """
     location = Location(**location_in.model_dump())
     db.add(location)
     await db.commit()
@@ -64,14 +86,21 @@ async def create_location(
     return location
 
 
-@router.patch("/{location_id}", response_model=LocationResponse)
+@router.patch(
+    "/{location_id}",
+    response_model=LocationResponse,
+    tags=["locations"],
+    responses={
+        404: {"description": "Sede no encontrada"},
+    },
+)
 async def update_location(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     location_id: UUID,
     location_in: LocationUpdate,
 ) -> Location:
-    """Update a location (admin only)."""
+    """Actualizar una sede parcialmente. Requiere rol admin."""
     result = await db.execute(select(Location).where(Location.id == location_id))
     location = result.scalar_one_or_none()
 
@@ -90,13 +119,20 @@ async def update_location(
     return location
 
 
-@router.delete("/{location_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{location_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    tags=["locations"],
+    responses={
+        404: {"description": "Sede no encontrada"},
+    },
+)
 async def delete_location(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     location_id: UUID,
 ) -> None:
-    """Delete a location (admin only)."""
+    """Eliminar una sede. Requiere rol admin."""
     result = await db.execute(select(Location).where(Location.id == location_id))
     location = result.scalar_one_or_none()
 

--- a/backend/app/api/v1/endpoints/positions.py
+++ b/backend/app/api/v1/endpoints/positions.py
@@ -13,14 +13,18 @@ from app.schemas.position import PositionCreate, PositionUpdate, PositionRespons
 router = APIRouter()
 
 
-@router.get("/", response_model=list[PositionResponse])
+@router.get(
+    "/",
+    response_model=list[PositionResponse],
+    tags=["positions"],
+)
 async def list_positions(
     db: Annotated[AsyncSession, Depends(get_db)],
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
     active_only: bool = True,
 ) -> list[Position]:
-    """List all positions."""
+    """Listar cargos y puestos. No requiere autenticación."""
     query = select(Position)
 
     if active_only:
@@ -32,12 +36,19 @@ async def list_positions(
     return result.scalars().all()
 
 
-@router.get("/{position_id}", response_model=PositionResponse)
+@router.get(
+    "/{position_id}",
+    response_model=PositionResponse,
+    tags=["positions"],
+    responses={
+        404: {"description": "Puesto no encontrado"},
+    },
+)
 async def get_position(
     db: Annotated[AsyncSession, Depends(get_db)],
     position_id: UUID,
 ) -> Position:
-    """Get a specific position."""
+    """Obtener un puesto por su UUID."""
     result = await db.execute(select(Position).where(Position.id == position_id))
     position = result.scalar_one_or_none()
 
@@ -50,13 +61,21 @@ async def get_position(
     return position
 
 
-@router.post("/", response_model=PositionResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/",
+    response_model=PositionResponse,
+    status_code=status.HTTP_201_CREATED,
+    tags=["positions"],
+    responses={
+        400: {"description": "Ya existe un puesto con ese nombre — el nombre debe ser único"},
+    },
+)
 async def create_position(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     position_in: PositionCreate,
 ) -> Position:
-    """Create a new position (admin only)."""
+    """Crear un nuevo cargo o puesto. Requiere rol admin. El nombre debe ser único."""
     # Check if name already exists
     result = await db.execute(select(Position).where(Position.name == position_in.name))
     if result.scalar_one_or_none():
@@ -72,14 +91,21 @@ async def create_position(
     return position
 
 
-@router.patch("/{position_id}", response_model=PositionResponse)
+@router.patch(
+    "/{position_id}",
+    response_model=PositionResponse,
+    tags=["positions"],
+    responses={
+        404: {"description": "Puesto no encontrado"},
+    },
+)
 async def update_position(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     position_id: UUID,
     position_in: PositionUpdate,
 ) -> Position:
-    """Update a position (admin only)."""
+    """Actualizar un puesto parcialmente. Requiere rol admin."""
     result = await db.execute(select(Position).where(Position.id == position_id))
     position = result.scalar_one_or_none()
 
@@ -98,13 +124,20 @@ async def update_position(
     return position
 
 
-@router.delete("/{position_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/{position_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    tags=["positions"],
+    responses={
+        404: {"description": "Puesto no encontrado"},
+    },
+)
 async def delete_position(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     position_id: UUID,
 ) -> None:
-    """Delete a position (admin only)."""
+    """Eliminar un puesto. Requiere rol admin."""
     result = await db.execute(select(Position).where(Position.id == position_id))
     position = result.scalar_one_or_none()
 

--- a/backend/app/api/v1/endpoints/schedules.py
+++ b/backend/app/api/v1/endpoints/schedules.py
@@ -43,14 +43,23 @@ router = APIRouter()
 # ==================== SCHEDULE PATTERNS ====================
 
 
-@router.get("/patterns", response_model=list[ScheduleResponse])
+@router.get(
+    "/patterns",
+    response_model=list[ScheduleResponse],
+    tags=["schedules"],
+)
 async def list_schedule_patterns(
     db: Annotated[AsyncSession, Depends(get_db)],
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
     active_only: bool = True,
 ) -> list[Schedule]:
-    """List all schedule patterns."""
+    """
+    Listar patrones de horario reutilizables.
+
+    Un patrón define horario de entrada/salida y se puede asignar a uno o varios
+    empleados para días específicos. Ejemplos: "Turno Mañana 7-13h", "Turno Tarde 14-20h".
+    """
     query = select(Schedule)
     if active_only:
         query = query.where(Schedule.is_active == True)
@@ -59,12 +68,19 @@ async def list_schedule_patterns(
     return result.scalars().all()
 
 
-@router.get("/patterns/{pattern_id}", response_model=ScheduleResponse)
+@router.get(
+    "/patterns/{pattern_id}",
+    response_model=ScheduleResponse,
+    tags=["schedules"],
+    responses={
+        404: {"description": "Patrón de horario no encontrado"},
+    },
+)
 async def get_schedule_pattern(
     db: Annotated[AsyncSession, Depends(get_db)],
     pattern_id: UUID,
 ) -> Schedule:
-    """Get a specific schedule pattern."""
+    """Obtener un patrón de horario por su UUID."""
     result = await db.execute(select(Schedule).where(Schedule.id == pattern_id))
     pattern = result.scalar_one_or_none()
     if not pattern:
@@ -75,14 +91,20 @@ async def get_schedule_pattern(
 
 
 @router.post(
-    "/patterns", response_model=ScheduleResponse, status_code=status.HTTP_201_CREATED
+    "/patterns",
+    response_model=ScheduleResponse,
+    status_code=status.HTTP_201_CREATED,
+    tags=["schedules"],
+    responses={
+        400: {"description": "Ya existe un patrón con ese nombre"},
+    },
 )
 async def create_schedule_pattern(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     pattern_in: ScheduleCreate,
 ) -> Schedule:
-    """Create a new schedule pattern (admin only)."""
+    """Crear un nuevo patrón de horario reutilizable. Requiere rol admin. El nombre debe ser único."""
     result = await db.execute(select(Schedule).where(Schedule.name == pattern_in.name))
     if result.scalar_one_or_none():
         raise HTTPException(
@@ -97,14 +119,21 @@ async def create_schedule_pattern(
     return pattern
 
 
-@router.patch("/patterns/{pattern_id}", response_model=ScheduleResponse)
+@router.patch(
+    "/patterns/{pattern_id}",
+    response_model=ScheduleResponse,
+    tags=["schedules"],
+    responses={
+        404: {"description": "Patrón de horario no encontrado"},
+    },
+)
 async def update_schedule_pattern(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     pattern_id: UUID,
     pattern_in: ScheduleUpdate,
 ) -> Schedule:
-    """Update a schedule pattern (admin only)."""
+    """Actualizar un patrón de horario parcialmente. Requiere rol admin."""
     result = await db.execute(select(Schedule).where(Schedule.id == pattern_id))
     pattern = result.scalar_one_or_none()
     if not pattern:
@@ -121,13 +150,20 @@ async def update_schedule_pattern(
     return pattern
 
 
-@router.delete("/patterns/{pattern_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/patterns/{pattern_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    tags=["schedules"],
+    responses={
+        404: {"description": "Patrón de horario no encontrado"},
+    },
+)
 async def delete_schedule_pattern(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     pattern_id: UUID,
 ) -> None:
-    """Delete a schedule pattern (admin only)."""
+    """Eliminar un patrón de horario. Requiere rol admin."""
     result = await db.execute(select(Schedule).where(Schedule.id == pattern_id))
     pattern = result.scalar_one_or_none()
     if not pattern:
@@ -141,14 +177,24 @@ async def delete_schedule_pattern(
 # ==================== SCHEDULE ASSIGNMENTS ====================
 
 
-@router.get("/assignments", response_model=list[ScheduleAssignmentResponse])
+@router.get(
+    "/assignments",
+    response_model=list[ScheduleAssignmentResponse],
+    tags=["schedules"],
+)
 async def list_assignments(
     db: Annotated[AsyncSession, Depends(get_db)],
     employee_id: UUID | None = None,
     date_from: date | None = None,
     date_to: date | None = None,
 ) -> list[ScheduleAssignment]:
-    """List schedule assignments with optional filters."""
+    """
+    Listar asignaciones de horario con filtros opcionales.
+
+    Las asignaciones vinculan un patrón de horario a un empleado para una fecha concreta.
+    Filtros disponibles: `employee_id`, `date_from`, `date_to` (todos opcionales, combinables).
+    Resultados ordenados por fecha ascendente.
+    """
     query = select(ScheduleAssignment)
 
     if employee_id:
@@ -167,13 +213,22 @@ async def list_assignments(
     "/assignments",
     response_model=ScheduleAssignmentResponse,
     status_code=status.HTTP_201_CREATED,
+    tags=["schedules"],
 )
 async def create_assignment(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     assignment_in: ScheduleAssignmentCreate,
 ) -> ScheduleAssignment:
-    """Create or update a schedule assignment for a specific date."""
+    """
+    Asignar un patrón de horario a un empleado para una fecha específica. Requiere rol admin.
+
+    Comportamiento upsert: si ya existe una asignación para ese empleado y fecha,
+    la actualiza en lugar de crear un duplicado.
+
+    Para marcar un día libre sin patrón, usar `is_day_off: true`.
+    Para horario personalizado sin patrón, usar `custom_check_in` y `custom_check_out`.
+    """
     # Check if assignment already exists for this employee and date
     result = await db.execute(
         select(ScheduleAssignment).where(
@@ -206,13 +261,25 @@ async def create_assignment(
     return assignment
 
 
-@router.post("/assignments/bulk", status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/assignments/bulk",
+    status_code=status.HTTP_201_CREATED,
+    tags=["schedules"],
+)
 async def create_bulk_assignments(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     bulk_in: BulkAssignmentCreate,
 ) -> dict:
-    """Create assignments for multiple employees and dates."""
+    """
+    Asignar un patrón de horario a múltiples empleados y fechas en una sola llamada. Requiere rol admin.
+
+    Útil para configurar horarios semanales o quincenales en bloque.
+    Acepta listas de `employee_ids` y `dates` — genera el producto cartesiano de ambas.
+
+    Comportamiento upsert por cada par (empleado, fecha): actualiza si existe, crea si no.
+    La respuesta incluye `created` y `updated` con los conteos respectivos.
+    """
     created_count = 0
     updated_count = 0
 
@@ -247,13 +314,20 @@ async def create_bulk_assignments(
     return {"created": created_count, "updated": updated_count}
 
 
-@router.delete("/assignments/{assignment_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/assignments/{assignment_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    tags=["schedules"],
+    responses={
+        404: {"description": "Asignación no encontrada"},
+    },
+)
 async def delete_assignment(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     assignment_id: UUID,
 ) -> None:
-    """Delete a schedule assignment."""
+    """Eliminar una asignación de horario. Requiere rol admin."""
     result = await db.execute(
         select(ScheduleAssignment).where(ScheduleAssignment.id == assignment_id)
     )
@@ -269,7 +343,11 @@ async def delete_assignment(
 # ==================== SCHEDULE EXCEPTIONS ====================
 
 
-@router.get("/exceptions", response_model=list[ScheduleExceptionResponse])
+@router.get(
+    "/exceptions",
+    response_model=list[ScheduleExceptionResponse],
+    tags=["schedules"],
+)
 async def list_exceptions(
     db: Annotated[AsyncSession, Depends(get_db)],
     employee_id: UUID | None = None,
@@ -277,7 +355,20 @@ async def list_exceptions(
     date_from: date | None = None,
     date_to: date | None = None,
 ) -> list[ScheduleException]:
-    """List schedule exceptions with optional filters."""
+    """
+    Listar excepciones de horario con filtros opcionales.
+
+    Tipos de excepción disponibles (`exception_type`):
+    - `vacation` — vacaciones
+    - `holiday` — feriado nacional o institucional
+    - `sick_leave` — incapacidad médica
+    - `permission` — permiso con o sin goce de sueldo
+    - `other` — otro motivo
+
+    **Nota:** Las excepciones con `employee_id = null` aplican a **todos** los empleados
+    (útil para feriados globales). Al filtrar por `employee_id`, se devuelven tanto las
+    excepciones individuales del empleado como las globales.
+    """
     query = select(ScheduleException)
 
     if employee_id:
@@ -303,13 +394,25 @@ async def list_exceptions(
     "/exceptions",
     response_model=ScheduleExceptionResponse,
     status_code=status.HTTP_201_CREATED,
+    tags=["schedules"],
 )
 async def create_exception(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     exception_in: ScheduleExceptionCreate,
 ) -> ScheduleException:
-    """Create a schedule exception (vacation, holiday, sick leave, etc.)."""
+    """
+    Crear una excepción de horario. Requiere rol admin.
+
+    Tipos disponibles: `vacation`, `holiday`, `sick_leave`, `permission`, `other`.
+
+    Omitir `employee_id` para crear una excepción **global** que aplica a todos los empleados
+    (útil para feriados nacionales o cierre institucional).
+
+    Si `has_work_hours: true`, se pueden especificar `work_check_in` y `work_check_out`
+    para días con horario reducido (p.ej. feriado con guardia). Si `has_work_hours: false`,
+    el día se marca como descanso.
+    """
     exception = ScheduleException(
         **exception_in.model_dump(), created_by=current_user.id
     )
@@ -319,14 +422,21 @@ async def create_exception(
     return exception
 
 
-@router.patch("/exceptions/{exception_id}", response_model=ScheduleExceptionResponse)
+@router.patch(
+    "/exceptions/{exception_id}",
+    response_model=ScheduleExceptionResponse,
+    tags=["schedules"],
+    responses={
+        404: {"description": "Excepción no encontrada"},
+    },
+)
 async def update_exception(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     exception_id: UUID,
     exception_in: ScheduleExceptionUpdate,
 ) -> ScheduleException:
-    """Update a schedule exception."""
+    """Actualizar una excepción de horario parcialmente. Requiere rol admin."""
     result = await db.execute(
         select(ScheduleException).where(ScheduleException.id == exception_id)
     )
@@ -345,13 +455,20 @@ async def update_exception(
     return exception
 
 
-@router.delete("/exceptions/{exception_id}", status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    "/exceptions/{exception_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    tags=["schedules"],
+    responses={
+        404: {"description": "Excepción no encontrada"},
+    },
+)
 async def delete_exception(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     exception_id: UUID,
 ) -> None:
-    """Delete a schedule exception."""
+    """Eliminar una excepción de horario. Requiere rol admin."""
     result = await db.execute(
         select(ScheduleException).where(ScheduleException.id == exception_id)
     )
@@ -367,16 +484,39 @@ async def delete_exception(
 # ==================== CALENDAR VIEW ====================
 
 
-@router.get("/calendar", response_model=CalendarResponse)
+@router.get(
+    "/calendar",
+    response_model=CalendarResponse,
+    tags=["schedules"],
+)
 async def get_calendar(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_user)],
-    start_date: date = Query(..., description="Start date of the calendar view"),
-    end_date: date = Query(..., description="End date of the calendar view"),
+    start_date: date = Query(..., description="Fecha de inicio del rango (YYYY-MM-DD)"),
+    end_date: date = Query(..., description="Fecha de fin del rango (YYYY-MM-DD)"),
     department_id: UUID | None = None,
     employee_id: UUID | None = None,
 ) -> CalendarResponse:
-    """Get calendar view with schedules for all employees in a date range."""
+    """
+    Vista consolidada de horarios para todos los empleados en un rango de fechas. Requiere autenticación.
+
+    Para cada empleado y cada día del rango, resuelve el horario aplicable
+    siguiendo esta lógica de prioridad (de mayor a menor):
+
+    1. **Excepción** (`vacation`, `holiday`, `sick_leave`, `permission`, `other`) —
+       si existe una excepción individual o global para ese día, tiene prioridad absoluta.
+       Color: gris (día libre) o azul (excepción con horas de trabajo especiales).
+    2. **Asignación específica** — si hay una asignación para ese empleado y fecha concreta,
+       aplica el patrón asignado o el horario personalizado. Color: color del patrón o violeta
+       si es horario custom.
+    3. **Horario por defecto** (`EmployeeSchedule`) — si no hay excepción ni asignación,
+       se usa el patrón asignado al empleado para ese día de la semana.
+
+    **Filtros opcionales:** `department_id` para ver solo un departamento,
+    `employee_id` para ver solo un empleado.
+
+    La respuesta es una grilla: una fila por empleado, una columna por día del rango.
+    """
 
     # Get employees
     emp_query = select(Employee).where(Employee.is_active == True)

--- a/backend/app/api/v1/endpoints/settings.py
+++ b/backend/app/api/v1/endpoints/settings.py
@@ -13,11 +13,23 @@ from app.schemas.settings import SettingsCreate, SettingsUpdate, SettingsRespons
 router = APIRouter()
 
 
-@router.get("/", response_model=SettingsResponse)
+@router.get(
+    "/",
+    response_model=SettingsResponse,
+    tags=["settings"],
+    responses={
+        404: {"description": "Configuración no inicializada — ejecutar seed de datos"},
+    },
+)
 async def get_settings(
     db: Annotated[AsyncSession, Depends(get_db)],
 ) -> Settings:
-    """Get system settings (singleton)."""
+    """
+    Obtener la configuración global del sistema.
+
+    Registro singleton — solo puede existir uno. Si no está inicializado,
+    ejecutar el seed de datos o usar `POST /settings/` para crearlo.
+    """
     result = await db.execute(select(Settings).limit(1))
     settings = result.scalar_one_or_none()
 
@@ -30,13 +42,23 @@ async def get_settings(
     return settings
 
 
-@router.put("/", response_model=SettingsResponse)
+@router.put(
+    "/",
+    response_model=SettingsResponse,
+    tags=["settings"],
+)
 async def update_settings(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     settings_in: SettingsUpdate,
 ) -> Settings:
-    """Update system settings (admin only)."""
+    """
+    Actualizar la configuración global del sistema. Requiere rol admin.
+
+    Si la configuración no existe aún, la crea automáticamente (upsert).
+    Usar este endpoint para cambiar nombre de empresa, dominio de email,
+    dirección, slogan o logo. Todos los campos son opcionales.
+    """
     result = await db.execute(select(Settings).limit(1))
     settings = result.scalar_one_or_none()
 
@@ -62,13 +84,26 @@ async def update_settings(
     return settings
 
 
-@router.post("/", response_model=SettingsResponse, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/",
+    response_model=SettingsResponse,
+    status_code=status.HTTP_201_CREATED,
+    tags=["settings"],
+    responses={
+        400: {"description": "La configuración ya existe — usar PUT para actualizar"},
+    },
+)
 async def create_settings(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     settings_in: SettingsCreate,
 ) -> Settings:
-    """Create system settings (only if none exist)."""
+    """
+    Inicializar la configuración del sistema por primera vez. Requiere rol admin.
+
+    Solo puede ejecutarse una vez — si ya existe configuración, devuelve 400.
+    Para actualizaciones posteriores usar `PUT /settings/`.
+    """
     result = await db.execute(select(Settings).limit(1))
     existing = result.scalar_one_or_none()
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,10 +18,111 @@ async def lifespan(app: FastAPI):
     print(f"Shutting down {settings.app_name}...")
 
 
+openapi_tags = [
+    {
+        "name": "auth",
+        "description": (
+            "Autenticación y gestión de sesión. "
+            "El login usa formato OAuth2 (`application/x-www-form-urlencoded`). "
+            "Devuelve `access_token` (30 min) y `refresh_token` (7 días)."
+        ),
+    },
+    {
+        "name": "employees",
+        "description": (
+            "Gestión de catedráticos y empleados. "
+            "El campo `has_face_registered` indica si el empleado ya puede hacer check-in."
+        ),
+    },
+    {
+        "name": "faces",
+        "description": (
+            "Registro y verificación de embeddings faciales. "
+            "Usa `face_recognition` (dlib) para convertir fotos en vectores de 128 dimensiones "
+            "almacenados en PostgreSQL con la extensión `pgvector`."
+        ),
+    },
+    {
+        "name": "attendance",
+        "description": (
+            "Registro de asistencia por reconocimiento facial. "
+            "Los endpoints `check-in` y `check-out` **no requieren autenticación** — "
+            "el rostro es la autenticación. La geolocalización se valida pero no bloquea el registro."
+        ),
+    },
+    {
+        "name": "departments",
+        "description": "Gestión de facultades y departamentos. CRUD estándar.",
+    },
+    {
+        "name": "positions",
+        "description": (
+            "Gestión de cargos y puestos. "
+            "El nombre del puesto debe ser único."
+        ),
+    },
+    {
+        "name": "locations",
+        "description": (
+            "Sedes de trabajo con coordenadas GPS y radio de validación. "
+            "Cada empleado puede tener asignada una sede. "
+            "El `radius_meters` define cuántos metros alrededor de la sede son válidos para el registro."
+        ),
+    },
+    {
+        "name": "schedules",
+        "description": (
+            "Sistema de horarios. Incluye patrones reutilizables, "
+            "asignaciones por fecha, asignaciones masivas y excepciones "
+            "(vacaciones, feriados, permisos). La vista `/calendar` consolida todo."
+        ),
+    },
+    {
+        "name": "settings",
+        "description": (
+            "Configuración global del sistema (singleton). "
+            "Solo puede existir un registro. Usar `PUT` para actualizar."
+        ),
+    },
+]
+
 app = FastAPI(
-    title=settings.app_name,
-    description="Biometric Attendance System API with Face Recognition",
+    title="Sistema Biométrico de Asistencia — API",
+    description="""
+API REST para el sistema de control de asistencia de catedráticos mediante reconocimiento facial y geolocalización.
+
+## Autenticación
+
+La mayoría de endpoints requieren un **JWT Bearer token**.
+
+1. Hacer `POST /api/v1/auth/login` con email y password
+2. Copiar el `access_token` de la respuesta
+3. En Swagger: click en **Authorize** → ingresar `Bearer <token>`
+4. En Postman/Insomnia: header `Authorization: Bearer <token>`
+
+Los endpoints `POST /attendance/check-in` y `POST /attendance/check-out`
+**no requieren token** — el reconocimiento facial es la autenticación.
+
+## Reconocimiento facial
+
+Las fotos deben enviarse en **base64** dentro del JSON.
+Enviar entre 1 y 5 fotos por request. Se recomienda 3 fotos con 250ms de diferencia.
+
+## Geolocalización
+
+Las coordenadas GPS son **opcionales**. Si se envían, el backend calcula la distancia
+a la sede asignada del empleado usando la fórmula de Haversine.
+El resultado se guarda en `geo_validated` pero **no bloquea** el registro de asistencia.
+""",
     version="1.0.0",
+    contact={
+        "name": "SistemasLab UMG",
+        "email": "sistemas@sistemaslab.dev",
+    },
+    license_info={
+        "name": "Privado — UMG",
+    },
+    openapi_tags=openapi_tags,
     lifespan=lifespan,
     docs_url="/docs",
     redoc_url="/redoc",

--- a/backend/app/schemas/attendance.py
+++ b/backend/app/schemas/attendance.py
@@ -1,15 +1,45 @@
 from datetime import datetime, date
 from uuid import UUID
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+_BASE64_IMAGE_EXAMPLE = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBg..."
 
 
 class AttendanceCheckIn(BaseModel):
-    images: list[str] = Field(..., min_length=1, max_length=5)  # Base64 encoded images
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "images": [_BASE64_IMAGE_EXAMPLE],
+                "latitude": 14.6407,
+                "longitude": -90.5133,
+            }
+        }
+    )
+
+    images: list[str] = Field(
+        ...,
+        min_length=1,
+        max_length=5,
+        description=(
+            "1 a 5 fotos del rostro en formato base64 (data URL o base64 puro). "
+            "Se recomienda 3 fotos con 250 ms de diferencia entre capturas."
+        ),
+    )
     image: str | None = None  # DEPRECATED: backward compat alias
     device_id: UUID | None = None
-    latitude: float | None = Field(default=None, ge=-90, le=90)
-    longitude: float | None = Field(default=None, ge=-180, le=180)
+    latitude: float | None = Field(
+        default=None,
+        ge=-90,
+        le=90,
+        description="Latitud GPS del dispositivo. Opcional — no bloquea el registro si se omite.",
+    )
+    longitude: float | None = Field(
+        default=None,
+        ge=-180,
+        le=180,
+        description="Longitud GPS del dispositivo. Opcional — no bloquea el registro si se omite.",
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -22,11 +52,39 @@ class AttendanceCheckIn(BaseModel):
 
 
 class AttendanceCheckOut(BaseModel):
-    images: list[str] = Field(..., min_length=1, max_length=5)  # Base64 encoded images
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "images": [_BASE64_IMAGE_EXAMPLE],
+                "latitude": 14.6407,
+                "longitude": -90.5133,
+            }
+        }
+    )
+
+    images: list[str] = Field(
+        ...,
+        min_length=1,
+        max_length=5,
+        description=(
+            "1 a 5 fotos del rostro en formato base64 (data URL o base64 puro). "
+            "Se recomienda 3 fotos con 250 ms de diferencia entre capturas."
+        ),
+    )
     image: str | None = None  # DEPRECATED: backward compat alias
     device_id: UUID | None = None
-    latitude: float | None = Field(default=None, ge=-90, le=90)
-    longitude: float | None = Field(default=None, ge=-180, le=180)
+    latitude: float | None = Field(
+        default=None,
+        ge=-90,
+        le=90,
+        description="Latitud GPS del dispositivo. Opcional — no bloquea el registro si se omite.",
+    )
+    longitude: float | None = Field(
+        default=None,
+        ge=-180,
+        le=180,
+        description="Longitud GPS del dispositivo. Opcional — no bloquea el registro si se omite.",
+    )
 
     @model_validator(mode="before")
     @classmethod

--- a/backend/app/schemas/employee.py
+++ b/backend/app/schemas/employee.py
@@ -1,7 +1,7 @@
 from datetime import datetime, date
 from uuid import UUID
 
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, ConfigDict, EmailStr
 
 from app.schemas.position import PositionResponse
 from app.schemas.department import DepartmentResponse
@@ -18,6 +18,22 @@ class EmployeeBase(BaseModel):
 
 
 class EmployeeCreate(EmployeeBase):
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "employee_code": "EMP-001",
+                "first_name": "María",
+                "last_name": "López",
+                "email": "mlopez@sistemaslab.dev",
+                "phone": "+502 5555-0001",
+                "hire_date": "2024-01-15",
+                "department_id": "550e8400-e29b-41d4-a716-446655440000",
+                "position_id": "550e8400-e29b-41d4-a716-446655440001",
+                "location_id": "550e8400-e29b-41d4-a716-446655440002",
+            }
+        }
+    )
+
     department_id: UUID | None = None
     position_id: UUID | None = None
     location_id: UUID | None = None

--- a/backend/app/schemas/face.py
+++ b/backend/app/schemas/face.py
@@ -1,7 +1,9 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
+
+_BASE64_IMAGE_EXAMPLE = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBg..."
 
 
 class StageMetrics(BaseModel):
@@ -13,8 +15,29 @@ class StageMetrics(BaseModel):
 
 
 class FaceRegisterRequest(BaseModel):
-    employee_id: UUID
-    images: list[str]  # List of base64 encoded images
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "employee_id": "550e8400-e29b-41d4-a716-446655440000",
+                "images": [
+                    _BASE64_IMAGE_EXAMPLE,
+                    _BASE64_IMAGE_EXAMPLE,
+                ],
+            }
+        }
+    )
+
+    employee_id: UUID = Field(
+        ...,
+        description="UUID del empleado. Obtenerlo desde GET /api/v1/employees/.",
+    )
+    images: list[str] = Field(
+        ...,
+        description=(
+            "1 a 5 fotos del empleado en base64 (data URL o base64 puro). "
+            "Usar fotos con distintos ángulos y luminosidad para mejor precisión del embedding."
+        ),
+    )
     session_id: str | None = None
     stage_metrics: StageMetrics | None = None
     capture_origin: str | None = None

--- a/backend/app/schemas/location.py
+++ b/backend/app/schemas/location.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class LocationBase(BaseModel):
@@ -13,7 +13,17 @@ class LocationBase(BaseModel):
 
 
 class LocationCreate(LocationBase):
-    pass
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "name": "Campus Central UMG",
+                "address": "6a Calle 22-38 Zona 10, Ciudad de Guatemala",
+                "latitude": 14.6407,
+                "longitude": -90.5133,
+                "radius_meters": 100,
+            }
+        }
+    )
 
 
 class LocationUpdate(BaseModel):


### PR DESCRIPTION
## Summary
- Adds full FastAPI metadata and 9 OpenAPI tags to `main.py`
- Adds schema examples (`model_config` + `json_schema_extra`) to attendance, face, employee, location schemas
- Adds docstrings and `responses={4xx}` to all 51 endpoints across 9 routers
- Closes #6

## Changes by phase
| Phase | Scope |
|-------|-------|
| 1 | Global metadata + 9 tags in main.py |
| 2 | Schema examples: attendance, face, employee, location |
| 3 | attendance endpoints (check-in, check-out, list, today) |
| 4 | auth endpoints (login, register, refresh, me) |
| 5 | employees CRUD (5 endpoints) |
| 6 | departments, positions, locations, settings |
| 7 | schedules (patterns, assignments, exceptions, calendar) |

## Test plan
- [ ] `GET /docs` shows 9 sections with correct metadata
- [ ] `GET /openapi.json` returns 51 endpoints
- [ ] Import into Postman — all endpoints with examples populate correctly
- [ ] Swagger "Authorize" button works with email/password