### PR TITLE
fix: add --proxy-headers to uvicorn to fix HTTP redirects behind Traefik

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -25,4 +25,4 @@ USER appuser
 
 EXPOSE 8000
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips=*"]


### PR DESCRIPTION
## Summary
- Adds `--proxy-headers --forwarded-allow-ips=*` to the uvicorn CMD in `backend/Dockerfile`
- Fixes Mixed Content errors in Angular Service Worker caused by HTTP redirect Location headers
- Closes #8

## Root Cause
uvicorn without `--proxy-headers` ignores `X-Forwarded-Proto: https` from Traefik. FastAPI's 307 redirects (trailing slash normalization) used `http://localhost:8000` as base, producing insecure Location headers.

## Test plan
- [ ] `POST /api/v1/auth/login` no longer has Mixed Content errors in incognito
- [ ] Admin panel loads employees list without `ERR_FAILED`
- [ ] Curl test: `curl -v http://localhost:8000/api/v1/employees` inside container shows `Location: https://...` in 307 response