### PR TITLE
feat(notifications): Phase 4 — WebSocket + in-app notifications + Resend email

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -25,4 +25,4 @@ USER appuser
 
 EXPOSE 8000
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips=*"]
+CMD ["sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --proxy-headers --forwarded-allow-ips=*"]

--- a/backend/alembic/versions/d1e2f3a4b5c6_add_permission_requests_and_user_roles.py
+++ b/backend/alembic/versions/d1e2f3a4b5c6_add_permission_requests_and_user_roles.py
@@ -1,0 +1,196 @@
+"""add_permission_requests_and_user_roles
+
+Revision ID: d1e2f3a4b5c6
+Revises: c7b4f2a8cd01
+Create Date: 2026-04-20
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = 'd1e2f3a4b5c6'
+down_revision = 'c7b4f2a8cd01'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # 1. Create userrole enum type
+    # ------------------------------------------------------------------
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE userrole AS ENUM (
+                'admin', 'director', 'coordinador', 'secretaria', 'catedratico'
+            );
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    """)
+
+    # ------------------------------------------------------------------
+    # 2. Alter users.role column: String(50) -> userrole enum
+    #    Uses USING cast to migrate existing string values.
+    # ------------------------------------------------------------------
+    op.execute("""
+        ALTER TABLE users
+            ALTER COLUMN role TYPE userrole
+            USING role::userrole;
+    """)
+    op.execute("""
+        ALTER TABLE users
+            ALTER COLUMN role SET DEFAULT 'admin'::userrole;
+    """)
+
+    # ------------------------------------------------------------------
+    # 3. Create enum types for permission_requests
+    # ------------------------------------------------------------------
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE permissionrequeststatus AS ENUM (
+                'pending', 'coordinator_approved', 'approved', 'rejected'
+            );
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    """)
+
+    op.execute("""
+        DO $$ BEGIN
+            CREATE TYPE rejectionstage AS ENUM (
+                'coordinator', 'director'
+            );
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
+    """)
+
+    # ------------------------------------------------------------------
+    # 4. Create permission_requests table
+    # ------------------------------------------------------------------
+    op.create_table(
+        'permission_requests',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+
+        # Requester and target employee
+        sa.Column(
+            'requested_by_user_id',
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey('users.id'),
+            nullable=False,
+        ),
+        sa.Column(
+            'employee_id',
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey('employees.id'),
+            nullable=False,
+        ),
+
+        # Request details
+        sa.Column('exception_type', sa.String(), nullable=False),
+        sa.Column('start_date', sa.Date(), nullable=False),
+        sa.Column('end_date', sa.Date(), nullable=False),
+        sa.Column('description', sa.Text(), nullable=True),
+
+        # Status
+        sa.Column(
+            'status',
+            postgresql.ENUM(
+                'pending', 'coordinator_approved', 'approved', 'rejected',
+                name='permissionrequeststatus',
+                create_type=False,
+            ),
+            nullable=False,
+            server_default='pending',
+        ),
+
+        # Coordinator review
+        sa.Column(
+            'coordinator_reviewed_by',
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey('users.id'),
+            nullable=True,
+        ),
+        sa.Column('coordinator_reviewed_at', sa.DateTime(), nullable=True),
+        sa.Column('coordinator_notes', sa.Text(), nullable=True),
+
+        # Director review
+        sa.Column(
+            'director_reviewed_by',
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey('users.id'),
+            nullable=True,
+        ),
+        sa.Column('director_reviewed_at', sa.DateTime(), nullable=True),
+        sa.Column('director_notes', sa.Text(), nullable=True),
+
+        # Rejection
+        sa.Column(
+            'rejection_stage',
+            postgresql.ENUM(
+                'coordinator', 'director',
+                name='rejectionstage',
+                create_type=False,
+            ),
+            nullable=True,
+        ),
+        sa.Column('rejection_reason', sa.Text(), nullable=True),
+
+        # Link to approved schedule exception
+        sa.Column(
+            'schedule_exception_id',
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey('schedule_exceptions.id'),
+            nullable=True,
+        ),
+
+        sa.Column(
+            'created_at',
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+    # Indexes for common query patterns
+    op.create_index(
+        'ix_permission_requests_employee_id',
+        'permission_requests',
+        ['employee_id'],
+    )
+    op.create_index(
+        'ix_permission_requests_requested_by',
+        'permission_requests',
+        ['requested_by_user_id'],
+    )
+    op.create_index(
+        'ix_permission_requests_status',
+        'permission_requests',
+        ['status'],
+    )
+
+
+def downgrade() -> None:
+    # Drop indexes
+    op.drop_index('ix_permission_requests_status')
+    op.drop_index('ix_permission_requests_requested_by')
+    op.drop_index('ix_permission_requests_employee_id')
+
+    # Drop table
+    op.drop_table('permission_requests')
+
+    # Drop new enum types
+    op.execute('DROP TYPE IF EXISTS rejectionstage')
+    op.execute('DROP TYPE IF EXISTS permissionrequeststatus')
+
+    # Revert users.role back to String
+    op.execute("""
+        ALTER TABLE users
+            ALTER COLUMN role TYPE varchar(50)
+            USING role::text;
+    """)
+    op.execute("ALTER TABLE users ALTER COLUMN role SET DEFAULT 'admin'")
+
+    # Drop userrole enum
+    op.execute('DROP TYPE IF EXISTS userrole')

--- a/backend/alembic/versions/e5f6a7b8c9d0_add_notifications_table.py
+++ b/backend/alembic/versions/e5f6a7b8c9d0_add_notifications_table.py
@@ -1,0 +1,61 @@
+"""add_notifications_table
+
+Revision ID: e5f6a7b8c9d0
+Revises: d1e2f3a4b5c6
+Create Date: 2026-04-20
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = 'e5f6a7b8c9d0'
+down_revision = 'd1e2f3a4b5c6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'notifications',
+        sa.Column('id', postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            'user_id',
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey('users.id'),
+            nullable=False,
+        ),
+        sa.Column('title', sa.String(200), nullable=False),
+        sa.Column('message', sa.Text(), nullable=False),
+        sa.Column('type', sa.String(50), nullable=False),
+        sa.Column('read', sa.Boolean(), nullable=False, server_default='false'),
+        sa.Column(
+            'request_id',
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey('permission_requests.id'),
+            nullable=True,
+        ),
+        sa.Column(
+            'created_at',
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+    op.create_index(
+        'ix_notifications_user_id',
+        'notifications',
+        ['user_id'],
+    )
+    op.create_index(
+        'ix_notifications_user_id_read',
+        'notifications',
+        ['user_id', 'read'],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_notifications_user_id_read')
+    op.drop_index('ix_notifications_user_id')
+    op.drop_table('notifications')

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -9,7 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import get_settings
 from app.core.security import decode_token
 from app.db.session import get_db
-from app.models.user import User
+from app.models.user import User, UserRole
 
 settings = get_settings()
 
@@ -60,4 +60,34 @@ async def get_current_active_admin(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Not enough permissions",
         )
+    return current_user
+
+
+async def get_current_coordinador_or_above(
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> User:
+    """Allow coordinador, director, admin"""
+    allowed = {UserRole.coordinador, UserRole.director, UserRole.admin}
+    if current_user.role not in allowed:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Permisos insuficientes")
+    return current_user
+
+
+async def get_current_director_or_above(
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> User:
+    """Allow director, admin"""
+    allowed = {UserRole.director, UserRole.admin}
+    if current_user.role not in allowed:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Permisos insuficientes")
+    return current_user
+
+
+async def get_current_secretaria_or_above(
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> User:
+    """Allow secretaria, coordinador, director, admin"""
+    allowed = {UserRole.secretaria, UserRole.coordinador, UserRole.director, UserRole.admin}
+    if current_user.role not in allowed:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Permisos insuficientes")
     return current_user

--- a/backend/app/api/v1/endpoints/attendance.py
+++ b/backend/app/api/v1/endpoints/attendance.py
@@ -7,7 +7,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.api.deps import get_db, get_current_active_admin
+from app.api.deps import get_db, get_current_active_admin, get_current_user
 from app.models.attendance import AttendanceRecord
 from app.models.employee import Employee
 from app.models.location import Location
@@ -329,12 +329,12 @@ async def check_out(
     response_model=list[AttendanceResponse],
     tags=["attendance"],
     responses={
-        401: {"description": "Token inválido o expirado — se requiere rol admin"},
+        401: {"description": "Token inválido o expirado"},
     },
 )
 async def list_attendance(
     db: Annotated[AsyncSession, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_user)],
     record_date: date | None = None,
     date_from: date | None = None,
     date_to: date | None = None,
@@ -344,7 +344,7 @@ async def list_attendance(
     limit: int = Query(100, ge=1, le=1000),
 ) -> list[AttendanceResponse]:
     """
-    Listar registros de asistencia con filtros opcionales. Requiere rol admin.
+    Listar registros de asistencia con filtros opcionales. Requiere autenticación.
 
     **Filtros disponibles (todos opcionales, combinables):**
     - `record_date` — fecha exacta (YYYY-MM-DD)
@@ -399,15 +399,15 @@ async def list_attendance(
     response_model=list[AttendanceResponse],
     tags=["attendance"],
     responses={
-        401: {"description": "Token inválido o expirado — se requiere rol admin"},
+        401: {"description": "Token inválido o expirado"},
     },
 )
 async def list_today_attendance(
     db: Annotated[AsyncSession, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_user)],
 ) -> list[AttendanceResponse]:
     """
-    Listar todos los registros de asistencia del día de hoy. Requiere rol admin.
+    Listar todos los registros de asistencia del día de hoy. Requiere autenticación.
 
     Shortcut de `GET /` filtrado por la fecha actual del servidor.
     Los resultados se ordenan por hora de check-in descendente (el más reciente primero).

--- a/backend/app/api/v1/endpoints/departments.py
+++ b/backend/app/api/v1/endpoints/departments.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import get_db, get_current_active_admin
+from app.api.deps import get_db, get_current_active_admin, get_current_secretaria_or_above
 from app.models.department import Department
 from app.models.user import User
 from app.schemas.department import DepartmentCreate, DepartmentUpdate, DepartmentResponse
@@ -66,13 +66,16 @@ async def get_department(
     response_model=DepartmentResponse,
     status_code=status.HTTP_201_CREATED,
     tags=["departments"],
+    responses={
+        403: {"description": "Permisos insuficientes"},
+    },
 )
 async def create_department(
     db: Annotated[AsyncSession, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_secretaria_or_above)],
     department_in: DepartmentCreate,
 ) -> Department:
-    """Crear un nuevo departamento o facultad. Requiere rol admin."""
+    """Crear un nuevo departamento o facultad. Requiere rol secretaria o superior."""
     department = Department(**department_in.model_dump())
     db.add(department)
     await db.commit()
@@ -85,16 +88,17 @@ async def create_department(
     response_model=DepartmentResponse,
     tags=["departments"],
     responses={
+        403: {"description": "Permisos insuficientes"},
         404: {"description": "Departamento no encontrado"},
     },
 )
 async def update_department(
     db: Annotated[AsyncSession, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_secretaria_or_above)],
     department_id: UUID,
     department_in: DepartmentUpdate,
 ) -> Department:
-    """Actualizar un departamento parcialmente. Requiere rol admin."""
+    """Actualizar un departamento parcialmente. Requiere rol secretaria o superior."""
     result = await db.execute(select(Department).where(Department.id == department_id))
     department = result.scalar_one_or_none()
 
@@ -118,6 +122,8 @@ async def update_department(
     status_code=status.HTTP_204_NO_CONTENT,
     tags=["departments"],
     responses={
+        401: {"description": "Token inválido o expirado — se requiere rol admin"},
+        403: {"description": "Solo el admin puede eliminar departamentos"},
         404: {"description": "Departamento no encontrado"},
     },
 )

--- a/backend/app/api/v1/endpoints/employees.py
+++ b/backend/app/api/v1/endpoints/employees.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.api.deps import get_db, get_current_active_admin
+from app.api.deps import get_db, get_current_active_admin, get_current_user, get_current_secretaria_or_above
 from app.models.employee import Employee
 from app.models.user import User
 from app.schemas.employee import EmployeeCreate, EmployeeUpdate, EmployeeResponse
@@ -19,18 +19,18 @@ router = APIRouter()
     response_model=list[EmployeeResponse],
     tags=["employees"],
     responses={
-        401: {"description": "Token inválido o expirado — se requiere rol admin"},
+        401: {"description": "Token inválido o expirado"},
     },
 )
 async def list_employees(
     db: Annotated[AsyncSession, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_user)],
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
     active_only: bool = True,
 ) -> list[EmployeeResponse]:
     """
-    Listar empleados/catedráticos registrados en el sistema. Requiere rol admin.
+    Listar empleados/catedráticos registrados en el sistema. Requiere autenticación.
 
     **Paginación:** usar `skip` y `limit` (máx. 1000 por request).
     Los resultados se ordenan alfabéticamente por apellido y nombre.
@@ -78,17 +78,17 @@ async def list_employees(
     response_model=EmployeeResponse,
     tags=["employees"],
     responses={
-        401: {"description": "Token inválido o expirado — se requiere rol admin"},
+        401: {"description": "Token inválido o expirado"},
         404: {"description": "Empleado no encontrado"},
     },
 )
 async def get_employee(
     db: Annotated[AsyncSession, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_user)],
     employee_id: UUID,
 ) -> EmployeeResponse:
     """
-    Obtener los datos de un empleado por su UUID. Requiere rol admin.
+    Obtener los datos de un empleado por su UUID. Requiere autenticación.
 
     Incluye el estado de registro facial (`has_face_registered`) y las referencias
     a departamento, puesto y sede asignados.
@@ -131,16 +131,17 @@ async def get_employee(
     tags=["employees"],
     responses={
         400: {"description": "El `employee_code` ya existe — debe ser único en el sistema"},
-        401: {"description": "Token inválido o expirado — se requiere rol admin"},
+        401: {"description": "Token inválido o expirado"},
+        403: {"description": "Permisos insuficientes"},
     },
 )
 async def create_employee(
     db: Annotated[AsyncSession, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_secretaria_or_above)],
     employee_in: EmployeeCreate,
 ) -> EmployeeResponse:
     """
-    Crear un nuevo empleado/catedrático. Requiere rol admin.
+    Crear un nuevo empleado/catedrático. Requiere rol secretaria o superior.
 
     El `employee_code` debe ser único (p.ej. `EMP-001`, número de carné, código institucional).
     El email también es requerido y se usa solo para identificación interna — no se envían correos.
@@ -185,18 +186,19 @@ async def create_employee(
     response_model=EmployeeResponse,
     tags=["employees"],
     responses={
-        401: {"description": "Token inválido o expirado — se requiere rol admin"},
+        401: {"description": "Token inválido o expirado"},
+        403: {"description": "Permisos insuficientes"},
         404: {"description": "Empleado no encontrado"},
     },
 )
 async def update_employee(
     db: Annotated[AsyncSession, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_secretaria_or_above)],
     employee_id: UUID,
     employee_in: EmployeeUpdate,
 ) -> EmployeeResponse:
     """
-    Actualizar parcialmente los datos de un empleado. Requiere rol admin.
+    Actualizar parcialmente los datos de un empleado. Requiere rol secretaria o superior.
 
     Solo se actualizan los campos incluidos en el body (PATCH semántico).
     Para dar de baja a un empleado sin eliminarlo, usar `is_active: false`.
@@ -248,6 +250,7 @@ async def update_employee(
     tags=["employees"],
     responses={
         401: {"description": "Token inválido o expirado — se requiere rol admin"},
+        403: {"description": "Solo el admin puede eliminar empleados"},
         404: {"description": "Empleado no encontrado"},
     },
 )

--- a/backend/app/api/v1/endpoints/locations.py
+++ b/backend/app/api/v1/endpoints/locations.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import get_db, get_current_active_admin
+from app.api.deps import get_db, get_current_active_admin, get_current_secretaria_or_above
 from app.models.location import Location
 from app.models.user import User
 from app.schemas.location import LocationCreate, LocationUpdate, LocationResponse
@@ -66,14 +66,17 @@ async def get_location(
     response_model=LocationResponse,
     status_code=status.HTTP_201_CREATED,
     tags=["locations"],
+    responses={
+        403: {"description": "Permisos insuficientes"},
+    },
 )
 async def create_location(
     db: Annotated[AsyncSession, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_secretaria_or_above)],
     location_in: LocationCreate,
 ) -> Location:
     """
-    Crear una nueva sede de trabajo. Requiere rol admin.
+    Crear una nueva sede de trabajo. Requiere rol secretaria o superior.
 
     El `radius_meters` define el radio en metros alrededor de las coordenadas GPS
     dentro del cual se considera válida la geolocalización de un empleado al hacer
@@ -91,16 +94,17 @@ async def create_location(
     response_model=LocationResponse,
     tags=["locations"],
     responses={
+        403: {"description": "Permisos insuficientes"},
         404: {"description": "Sede no encontrada"},
     },
 )
 async def update_location(
     db: Annotated[AsyncSession, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_secretaria_or_above)],
     location_id: UUID,
     location_in: LocationUpdate,
 ) -> Location:
-    """Actualizar una sede parcialmente. Requiere rol admin."""
+    """Actualizar una sede parcialmente. Requiere rol secretaria o superior."""
     result = await db.execute(select(Location).where(Location.id == location_id))
     location = result.scalar_one_or_none()
 
@@ -124,6 +128,8 @@ async def update_location(
     status_code=status.HTTP_204_NO_CONTENT,
     tags=["locations"],
     responses={
+        401: {"description": "Token inválido o expirado — se requiere rol admin"},
+        403: {"description": "Solo el admin puede eliminar sedes"},
         404: {"description": "Sede no encontrada"},
     },
 )

--- a/backend/app/api/v1/endpoints/notifications.py
+++ b/backend/app/api/v1/endpoints/notifications.py
@@ -1,0 +1,88 @@
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import get_current_user, get_db
+from app.models.notification import Notification
+from app.models.user import User
+from app.schemas.notification import NotificationResponse
+
+router = APIRouter()
+
+
+@router.get("/", response_model=list[NotificationResponse])
+async def list_notifications(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_user)],
+    unread_only: bool = False,
+) -> list[NotificationResponse]:
+    """
+    List notifications for the authenticated user.
+    Returns the 50 most recent, ordered newest first.
+    Pass `unread_only=true` to filter only unread ones.
+    """
+    q = (
+        select(Notification)
+        .where(Notification.user_id == current_user.id)
+        .order_by(Notification.created_at.desc())
+        .limit(50)
+    )
+    if unread_only:
+        q = q.where(Notification.read == False)  # noqa: E712
+    result = await db.execute(q)
+    return result.scalars().all()
+
+
+@router.get("/unread-count")
+async def unread_count(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> dict:
+    result = await db.execute(
+        select(func.count()).where(
+            Notification.user_id == current_user.id,
+            Notification.read == False,  # noqa: E712
+        )
+    )
+    return {"count": result.scalar()}
+
+
+@router.patch("/read-all")
+async def mark_all_read(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> dict:
+    await db.execute(
+        update(Notification)
+        .where(
+            Notification.user_id == current_user.id,
+            Notification.read == False,  # noqa: E712
+        )
+        .values(read=True)
+    )
+    await db.commit()
+    return {"ok": True}
+
+
+@router.patch("/{notification_id}/read", response_model=NotificationResponse)
+async def mark_read(
+    notification_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_user)],
+) -> NotificationResponse:
+    result = await db.execute(
+        select(Notification).where(
+            Notification.id == notification_id,
+            Notification.user_id == current_user.id,
+        )
+    )
+    notif = result.scalar_one_or_none()
+    if not notif:
+        raise HTTPException(status_code=404, detail="Notificación no encontrada")
+    notif.read = True
+    await db.commit()
+    await db.refresh(notif)
+    return notif

--- a/backend/app/api/v1/endpoints/permission_requests.py
+++ b/backend/app/api/v1/endpoints/permission_requests.py
@@ -1,0 +1,373 @@
+from datetime import datetime
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.deps import (
+    get_current_user,
+    get_current_coordinador_or_above,
+    get_db,
+)
+from app.models.permission_request import (
+    PermissionRequest,
+    PermissionRequestStatus,
+    RejectionStage,
+)
+from app.models.schedule import ScheduleException
+from app.models.user import User, UserRole
+from app.schemas.permission_request import (
+    PermissionRequestApprove,
+    PermissionRequestCreate,
+    PermissionRequestReject,
+    PermissionRequestResponse,
+)
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# POST /permission-requests  — any authenticated user
+# ---------------------------------------------------------------------------
+
+@router.post(
+    "/",
+    response_model=PermissionRequestResponse,
+    status_code=status.HTTP_201_CREATED,
+    tags=["permission-requests"],
+    responses={
+        422: {"description": "La solicitud debe realizarse con al menos 7 días de anticipación"},
+    },
+)
+async def create_permission_request(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_user)],
+    request_in: PermissionRequestCreate,
+) -> PermissionRequestResponse:
+    """
+    Crear una solicitud de permiso. Requiere autenticación.
+
+    La `start_date` debe ser al menos 7 días posterior a la fecha de hoy.
+    La solicitud queda en estado `pending` hasta que un coordinador la apruebe.
+    """
+    permission_request = PermissionRequest(
+        requested_by_user_id=current_user.id,
+        employee_id=request_in.employee_id,
+        exception_type=request_in.exception_type,
+        start_date=request_in.start_date,
+        end_date=request_in.end_date,
+        description=request_in.description,
+        status=PermissionRequestStatus.pending,
+    )
+    db.add(permission_request)
+    await db.commit()
+    await db.refresh(permission_request)
+    return PermissionRequestResponse.model_validate(permission_request)
+
+
+# ---------------------------------------------------------------------------
+# GET /permission-requests  — role-based visibility
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/",
+    response_model=list[PermissionRequestResponse],
+    tags=["permission-requests"],
+)
+async def list_permission_requests(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_user)],
+    status_filter: PermissionRequestStatus | None = Query(None, alias="status"),
+    employee_id: UUID | None = None,
+    skip: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=500),
+) -> list[PermissionRequestResponse]:
+    """
+    Listar solicitudes de permiso.
+
+    - `admin`, `director`, `coordinador`: ven **todas** las solicitudes.
+    - `secretaria`, `catedratico`: ven únicamente sus propias solicitudes.
+
+    Filtros opcionales: `status`, `employee_id`.
+    """
+    _privileged = {UserRole.admin, UserRole.director, UserRole.coordinador}
+
+    query = select(PermissionRequest)
+
+    if current_user.role not in _privileged:
+        # Restrict to own requests
+        query = query.where(PermissionRequest.requested_by_user_id == current_user.id)
+
+    if status_filter is not None:
+        query = query.where(PermissionRequest.status == status_filter)
+    if employee_id is not None:
+        query = query.where(PermissionRequest.employee_id == employee_id)
+
+    query = query.offset(skip).limit(limit).order_by(PermissionRequest.created_at.desc())
+
+    result = await db.execute(query)
+    records = result.scalars().all()
+    return [PermissionRequestResponse.model_validate(r) for r in records]
+
+
+# ---------------------------------------------------------------------------
+# GET /permission-requests/{request_id}
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/{request_id}",
+    response_model=PermissionRequestResponse,
+    tags=["permission-requests"],
+    responses={
+        403: {"description": "No autorizado para ver esta solicitud"},
+        404: {"description": "Solicitud no encontrada"},
+    },
+)
+async def get_permission_request(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_user)],
+    request_id: UUID,
+) -> PermissionRequestResponse:
+    """
+    Obtener una solicitud de permiso por su UUID.
+
+    - `admin`, `director`, `coordinador`: pueden ver cualquier solicitud.
+    - `secretaria`, `catedratico`: solo las propias.
+    """
+    result = await db.execute(
+        select(PermissionRequest).where(PermissionRequest.id == request_id)
+    )
+    permission_request = result.scalar_one_or_none()
+
+    if not permission_request:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Solicitud no encontrada",
+        )
+
+    _privileged = {UserRole.admin, UserRole.director, UserRole.coordinador}
+    if current_user.role not in _privileged:
+        if permission_request.requested_by_user_id != current_user.id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="No autorizado para ver esta solicitud",
+            )
+
+    return PermissionRequestResponse.model_validate(permission_request)
+
+
+# ---------------------------------------------------------------------------
+# PATCH /permission-requests/{request_id}/approve
+# ---------------------------------------------------------------------------
+
+@router.patch(
+    "/{request_id}/approve",
+    response_model=PermissionRequestResponse,
+    tags=["permission-requests"],
+    responses={
+        400: {"description": "No se puede aprobar en el estado actual"},
+        403: {"description": "Permisos insuficientes para esta etapa de aprobación"},
+        404: {"description": "Solicitud no encontrada"},
+    },
+)
+async def approve_permission_request(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_coordinador_or_above)],
+    request_id: UUID,
+    body: PermissionRequestApprove,
+) -> PermissionRequestResponse:
+    """
+    Aprobar una solicitud de permiso.
+
+    **Flujo de aprobación en dos etapas:**
+
+    1. `pending` → `coordinator_approved` (requiere rol `coordinador` o `admin`)
+    2. `coordinator_approved` → `approved` (requiere rol `director` o `admin`)
+       Al alcanzar `approved`, se crea automáticamente un `ScheduleException` vinculado.
+    """
+    result = await db.execute(
+        select(PermissionRequest).where(PermissionRequest.id == request_id)
+    )
+    permission_request = result.scalar_one_or_none()
+
+    if not permission_request:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Solicitud no encontrada",
+        )
+
+    now = datetime.utcnow()
+
+    if permission_request.status == PermissionRequestStatus.pending:
+        # Stage 1: coordinator approval
+        _allowed = {UserRole.coordinador, UserRole.admin}
+        if current_user.role not in _allowed:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Permisos insuficientes: se requiere rol coordinador o admin",
+            )
+        permission_request.status = PermissionRequestStatus.coordinator_approved
+        permission_request.coordinator_reviewed_by = current_user.id
+        permission_request.coordinator_reviewed_at = now
+        permission_request.coordinator_notes = body.notes
+
+    elif permission_request.status == PermissionRequestStatus.coordinator_approved:
+        # Stage 2: director approval
+        _allowed = {UserRole.director, UserRole.admin}
+        if current_user.role not in _allowed:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Permisos insuficientes: se requiere rol director o admin",
+            )
+        permission_request.status = PermissionRequestStatus.approved
+        permission_request.director_reviewed_by = current_user.id
+        permission_request.director_reviewed_at = now
+        permission_request.director_notes = body.notes
+
+        # Auto-create ScheduleException
+        schedule_exception = ScheduleException(
+            employee_id=permission_request.employee_id,
+            exception_type=permission_request.exception_type,
+            start_date=permission_request.start_date,
+            end_date=permission_request.end_date,
+            description=permission_request.description,
+            created_by=current_user.id,
+        )
+        db.add(schedule_exception)
+        await db.flush()  # Get the id without committing yet
+        permission_request.schedule_exception_id = schedule_exception.id
+
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No se puede aprobar en el estado actual",
+        )
+
+    await db.commit()
+    await db.refresh(permission_request)
+    return PermissionRequestResponse.model_validate(permission_request)
+
+
+# ---------------------------------------------------------------------------
+# PATCH /permission-requests/{request_id}/reject
+# ---------------------------------------------------------------------------
+
+@router.patch(
+    "/{request_id}/reject",
+    response_model=PermissionRequestResponse,
+    tags=["permission-requests"],
+    responses={
+        400: {"description": "No se puede rechazar en el estado actual"},
+        403: {"description": "Permisos insuficientes para esta etapa"},
+        404: {"description": "Solicitud no encontrada"},
+    },
+)
+async def reject_permission_request(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_coordinador_or_above)],
+    request_id: UUID,
+    body: PermissionRequestReject,
+) -> PermissionRequestResponse:
+    """
+    Rechazar una solicitud de permiso.
+
+    - Estado `pending`: requiere `coordinador` o `admin`.
+    - Estado `coordinator_approved`: requiere `director` o `admin`.
+    """
+    result = await db.execute(
+        select(PermissionRequest).where(PermissionRequest.id == request_id)
+    )
+    permission_request = result.scalar_one_or_none()
+
+    if not permission_request:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Solicitud no encontrada",
+        )
+
+    if permission_request.status == PermissionRequestStatus.pending:
+        _allowed = {UserRole.coordinador, UserRole.admin}
+        if current_user.role not in _allowed:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Permisos insuficientes: se requiere rol coordinador o admin",
+            )
+        permission_request.rejection_stage = RejectionStage.coordinator
+
+    elif permission_request.status == PermissionRequestStatus.coordinator_approved:
+        _allowed = {UserRole.director, UserRole.admin}
+        if current_user.role not in _allowed:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Permisos insuficientes: se requiere rol director o admin",
+            )
+        permission_request.rejection_stage = RejectionStage.director
+
+    else:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No se puede rechazar en el estado actual",
+        )
+
+    permission_request.status = PermissionRequestStatus.rejected
+    permission_request.rejection_reason = body.rejection_reason
+
+    await db.commit()
+    await db.refresh(permission_request)
+    return PermissionRequestResponse.model_validate(permission_request)
+
+
+# ---------------------------------------------------------------------------
+# DELETE /permission-requests/{request_id}
+# ---------------------------------------------------------------------------
+
+@router.delete(
+    "/{request_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    tags=["permission-requests"],
+    responses={
+        403: {"description": "Solo se puede eliminar una solicitud propia en estado pending"},
+        404: {"description": "Solicitud no encontrada"},
+    },
+)
+async def delete_permission_request(
+    db: Annotated[AsyncSession, Depends(get_db)],
+    current_user: Annotated[User, Depends(get_current_user)],
+    request_id: UUID,
+) -> None:
+    """
+    Eliminar una solicitud de permiso.
+
+    - Solo se puede eliminar si el estado es `pending`.
+    - El usuario debe ser el creador de la solicitud, o tener rol `admin`.
+    """
+    result = await db.execute(
+        select(PermissionRequest).where(PermissionRequest.id == request_id)
+    )
+    permission_request = result.scalar_one_or_none()
+
+    if not permission_request:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Solicitud no encontrada",
+        )
+
+    is_admin = current_user.role == UserRole.admin
+    is_owner = permission_request.requested_by_user_id == current_user.id
+
+    if not is_admin:
+        if not is_owner:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="No autorizado para eliminar esta solicitud",
+            )
+        if permission_request.status != PermissionRequestStatus.pending:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Solo se pueden eliminar solicitudes en estado pending",
+            )
+
+    await db.delete(permission_request)
+    await db.commit()

--- a/backend/app/api/v1/endpoints/permission_requests.py
+++ b/backend/app/api/v1/endpoints/permission_requests.py
@@ -24,6 +24,7 @@ from app.schemas.permission_request import (
     PermissionRequestReject,
     PermissionRequestResponse,
 )
+from app.services.notification_service import notify_user
 
 router = APIRouter()
 
@@ -213,6 +214,19 @@ async def approve_permission_request(
         permission_request.coordinator_reviewed_at = now
         permission_request.coordinator_notes = body.notes
 
+        await notify_user(
+            db=db,
+            user_id=str(permission_request.requested_by_user_id),
+            title="Solicitud en revisión",
+            message=(
+                f"Tu solicitud de {permission_request.exception_type} del "
+                f"{permission_request.start_date} fue aprobada por el coordinador y "
+                f"está pendiente de aprobación final por el director."
+            ),
+            notification_type="permission_coordinator_approved",
+            request_id=str(permission_request.id),
+        )
+
     elif permission_request.status == PermissionRequestStatus.coordinator_approved:
         # Stage 2: director approval
         _allowed = {UserRole.director, UserRole.admin}
@@ -238,6 +252,19 @@ async def approve_permission_request(
         db.add(schedule_exception)
         await db.flush()  # Get the id without committing yet
         permission_request.schedule_exception_id = schedule_exception.id
+
+        await notify_user(
+            db=db,
+            user_id=str(permission_request.requested_by_user_id),
+            title="Solicitud aprobada",
+            message=(
+                f"Tu solicitud de {permission_request.exception_type} del "
+                f"{permission_request.start_date} al {permission_request.end_date} "
+                f"fue aprobada."
+            ),
+            notification_type="permission_approved",
+            request_id=str(permission_request.id),
+        )
 
     else:
         raise HTTPException(
@@ -313,6 +340,19 @@ async def reject_permission_request(
 
     permission_request.status = PermissionRequestStatus.rejected
     permission_request.rejection_reason = body.rejection_reason
+
+    await notify_user(
+        db=db,
+        user_id=str(permission_request.requested_by_user_id),
+        title="Solicitud rechazada",
+        message=(
+            f"Tu solicitud de {permission_request.exception_type} del "
+            f"{permission_request.start_date} fue rechazada. "
+            f"Motivo: {body.rejection_reason}"
+        ),
+        notification_type="permission_rejected",
+        request_id=str(permission_request.id),
+    )
 
     await db.commit()
     await db.refresh(permission_request)

--- a/backend/app/api/v1/endpoints/positions.py
+++ b/backend/app/api/v1/endpoints/positions.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, status, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import get_db, get_current_active_admin
+from app.api.deps import get_db, get_current_active_admin, get_current_secretaria_or_above
 from app.models.position import Position
 from app.models.user import User
 from app.schemas.position import PositionCreate, PositionUpdate, PositionResponse
@@ -68,14 +68,15 @@ async def get_position(
     tags=["positions"],
     responses={
         400: {"description": "Ya existe un puesto con ese nombre — el nombre debe ser único"},
+        403: {"description": "Permisos insuficientes"},
     },
 )
 async def create_position(
     db: Annotated[AsyncSession, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_secretaria_or_above)],
     position_in: PositionCreate,
 ) -> Position:
-    """Crear un nuevo cargo o puesto. Requiere rol admin. El nombre debe ser único."""
+    """Crear un nuevo cargo o puesto. Requiere rol secretaria o superior. El nombre debe ser único."""
     # Check if name already exists
     result = await db.execute(select(Position).where(Position.name == position_in.name))
     if result.scalar_one_or_none():
@@ -96,16 +97,17 @@ async def create_position(
     response_model=PositionResponse,
     tags=["positions"],
     responses={
+        403: {"description": "Permisos insuficientes"},
         404: {"description": "Puesto no encontrado"},
     },
 )
 async def update_position(
     db: Annotated[AsyncSession, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_secretaria_or_above)],
     position_id: UUID,
     position_in: PositionUpdate,
 ) -> Position:
-    """Actualizar un puesto parcialmente. Requiere rol admin."""
+    """Actualizar un puesto parcialmente. Requiere rol secretaria o superior."""
     result = await db.execute(select(Position).where(Position.id == position_id))
     position = result.scalar_one_or_none()
 
@@ -129,6 +131,8 @@ async def update_position(
     status_code=status.HTTP_204_NO_CONTENT,
     tags=["positions"],
     responses={
+        401: {"description": "Token inválido o expirado — se requiere rol admin"},
+        403: {"description": "Solo el admin puede eliminar puestos"},
         404: {"description": "Puesto no encontrado"},
     },
 )

--- a/backend/app/api/v1/endpoints/schedules.py
+++ b/backend/app/api/v1/endpoints/schedules.py
@@ -7,7 +7,7 @@ from sqlalchemy import select, and_, or_
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.api.deps import get_db, get_current_active_admin, get_current_user
+from app.api.deps import get_db, get_current_active_admin, get_current_user, get_current_secretaria_or_above
 from app.models.schedule import (
     Schedule,
     EmployeeSchedule,
@@ -97,14 +97,15 @@ async def get_schedule_pattern(
     tags=["schedules"],
     responses={
         400: {"description": "Ya existe un patrón con ese nombre"},
+        403: {"description": "Permisos insuficientes"},
     },
 )
 async def create_schedule_pattern(
     db: Annotated[AsyncSession, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_secretaria_or_above)],
     pattern_in: ScheduleCreate,
 ) -> Schedule:
-    """Crear un nuevo patrón de horario reutilizable. Requiere rol admin. El nombre debe ser único."""
+    """Crear un nuevo patrón de horario reutilizable. Requiere rol secretaria o superior. El nombre debe ser único."""
     result = await db.execute(select(Schedule).where(Schedule.name == pattern_in.name))
     if result.scalar_one_or_none():
         raise HTTPException(
@@ -124,16 +125,17 @@ async def create_schedule_pattern(
     response_model=ScheduleResponse,
     tags=["schedules"],
     responses={
+        403: {"description": "Permisos insuficientes"},
         404: {"description": "Patrón de horario no encontrado"},
     },
 )
 async def update_schedule_pattern(
     db: Annotated[AsyncSession, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_secretaria_or_above)],
     pattern_id: UUID,
     pattern_in: ScheduleUpdate,
 ) -> Schedule:
-    """Actualizar un patrón de horario parcialmente. Requiere rol admin."""
+    """Actualizar un patrón de horario parcialmente. Requiere rol secretaria o superior."""
     result = await db.execute(select(Schedule).where(Schedule.id == pattern_id))
     pattern = result.scalar_one_or_none()
     if not pattern:
@@ -155,6 +157,7 @@ async def update_schedule_pattern(
     status_code=status.HTTP_204_NO_CONTENT,
     tags=["schedules"],
     responses={
+        403: {"description": "Solo el admin puede eliminar patrones"},
         404: {"description": "Patrón de horario no encontrado"},
     },
 )
@@ -214,14 +217,17 @@ async def list_assignments(
     response_model=ScheduleAssignmentResponse,
     status_code=status.HTTP_201_CREATED,
     tags=["schedules"],
+    responses={
+        403: {"description": "Permisos insuficientes"},
+    },
 )
 async def create_assignment(
     db: Annotated[AsyncSession, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_secretaria_or_above)],
     assignment_in: ScheduleAssignmentCreate,
 ) -> ScheduleAssignment:
     """
-    Asignar un patrón de horario a un empleado para una fecha específica. Requiere rol admin.
+    Asignar un patrón de horario a un empleado para una fecha específica. Requiere rol secretaria o superior.
 
     Comportamiento upsert: si ya existe una asignación para ese empleado y fecha,
     la actualiza en lugar de crear un duplicado.
@@ -265,14 +271,17 @@ async def create_assignment(
     "/assignments/bulk",
     status_code=status.HTTP_201_CREATED,
     tags=["schedules"],
+    responses={
+        403: {"description": "Permisos insuficientes"},
+    },
 )
 async def create_bulk_assignments(
     db: Annotated[AsyncSession, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_secretaria_or_above)],
     bulk_in: BulkAssignmentCreate,
 ) -> dict:
     """
-    Asignar un patrón de horario a múltiples empleados y fechas en una sola llamada. Requiere rol admin.
+    Asignar un patrón de horario a múltiples empleados y fechas en una sola llamada. Requiere rol secretaria o superior.
 
     Útil para configurar horarios semanales o quincenales en bloque.
     Acepta listas de `employee_ids` y `dates` — genera el producto cartesiano de ambas.
@@ -319,6 +328,7 @@ async def create_bulk_assignments(
     status_code=status.HTTP_204_NO_CONTENT,
     tags=["schedules"],
     responses={
+        403: {"description": "Solo el admin puede eliminar asignaciones"},
         404: {"description": "Asignación no encontrada"},
     },
 )
@@ -395,14 +405,17 @@ async def list_exceptions(
     response_model=ScheduleExceptionResponse,
     status_code=status.HTTP_201_CREATED,
     tags=["schedules"],
+    responses={
+        403: {"description": "Permisos insuficientes"},
+    },
 )
 async def create_exception(
     db: Annotated[AsyncSession, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_secretaria_or_above)],
     exception_in: ScheduleExceptionCreate,
 ) -> ScheduleException:
     """
-    Crear una excepción de horario. Requiere rol admin.
+    Crear una excepción de horario. Requiere rol secretaria o superior.
 
     Tipos disponibles: `vacation`, `holiday`, `sick_leave`, `permission`, `other`.
 
@@ -427,16 +440,17 @@ async def create_exception(
     response_model=ScheduleExceptionResponse,
     tags=["schedules"],
     responses={
+        403: {"description": "Permisos insuficientes"},
         404: {"description": "Excepción no encontrada"},
     },
 )
 async def update_exception(
     db: Annotated[AsyncSession, Depends(get_db)],
-    current_user: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_secretaria_or_above)],
     exception_id: UUID,
     exception_in: ScheduleExceptionUpdate,
 ) -> ScheduleException:
-    """Actualizar una excepción de horario parcialmente. Requiere rol admin."""
+    """Actualizar una excepción de horario parcialmente. Requiere rol secretaria o superior."""
     result = await db.execute(
         select(ScheduleException).where(ScheduleException.id == exception_id)
     )
@@ -460,6 +474,7 @@ async def update_exception(
     status_code=status.HTTP_204_NO_CONTENT,
     tags=["schedules"],
     responses={
+        403: {"description": "Solo el admin puede eliminar excepciones"},
         404: {"description": "Excepción no encontrada"},
     },
 )

--- a/backend/app/api/v1/endpoints/settings.py
+++ b/backend/app/api/v1/endpoints/settings.py
@@ -17,9 +17,6 @@ router = APIRouter()
     "/",
     response_model=SettingsResponse,
     tags=["settings"],
-    responses={
-        404: {"description": "Configuración no inicializada — ejecutar seed de datos"},
-    },
 )
 async def get_settings(
     db: Annotated[AsyncSession, Depends(get_db)],
@@ -27,17 +24,21 @@ async def get_settings(
     """
     Obtener la configuración global del sistema.
 
-    Registro singleton — solo puede existir uno. Si no está inicializado,
-    ejecutar el seed de datos o usar `POST /settings/` para crearlo.
+    Registro singleton — si no existe, se inicializa automáticamente con valores por defecto.
     """
     result = await db.execute(select(Settings).limit(1))
     settings = result.scalar_one_or_none()
 
     if not settings:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Settings not configured. Please run seed data.",
+        settings = Settings(
+            company_name="Universidad Mariano Gálvez",
+            email_domain="miumg.edu.gt",
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
         )
+        db.add(settings)
+        await db.commit()
+        await db.refresh(settings)
 
     return settings
 

--- a/backend/app/api/v1/endpoints/websocket.py
+++ b/backend/app/api/v1/endpoints/websocket.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Query
+
+from app.core.security import decode_token
+from app.services.websocket_manager import ws_manager
+
+router = APIRouter()
+
+
+@router.websocket("/ws/notifications")
+async def websocket_notifications(
+    websocket: WebSocket,
+    token: str = Query(...),
+) -> None:
+    """
+    WebSocket endpoint for real-time notifications.
+    Client connects with: ws://host/api/v1/ws/notifications?token=<JWT>
+    """
+    payload = decode_token(token)
+    if payload is None or payload.get("type") != "access":
+        await websocket.close(code=4001)
+        return
+
+    user_id = payload.get("sub")
+    if not user_id:
+        await websocket.close(code=4001)
+        return
+
+    await ws_manager.connect(websocket, str(user_id))
+    try:
+        while True:
+            # Keep connection alive — client can send "ping", we respond "pong"
+            data = await websocket.receive_text()
+            if data == "ping":
+                await websocket.send_text("pong")
+    except WebSocketDisconnect:
+        ws_manager.disconnect(websocket, str(user_id))

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -11,6 +11,8 @@ from app.api.v1.endpoints import (
     locations,
     schedules,
     permission_requests,
+    notifications,
+    websocket,
 )
 
 api_router = APIRouter()
@@ -29,3 +31,9 @@ api_router.include_router(
     prefix="/permission-requests",
     tags=["permission-requests"],
 )
+api_router.include_router(
+    notifications.router,
+    prefix="/notifications",
+    tags=["notifications"],
+)
+api_router.include_router(websocket.router, tags=["websocket"])

--- a/backend/app/api/v1/router.py
+++ b/backend/app/api/v1/router.py
@@ -1,6 +1,17 @@
 from fastapi import APIRouter
 
-from app.api.v1.endpoints import auth, employees, faces, attendance, settings, positions, departments, locations, schedules
+from app.api.v1.endpoints import (
+    auth,
+    employees,
+    faces,
+    attendance,
+    settings,
+    positions,
+    departments,
+    locations,
+    schedules,
+    permission_requests,
+)
 
 api_router = APIRouter()
 
@@ -13,3 +24,8 @@ api_router.include_router(positions.router, prefix="/positions", tags=["position
 api_router.include_router(departments.router, prefix="/departments", tags=["departments"])
 api_router.include_router(locations.router, prefix="/locations", tags=["locations"])
 api_router.include_router(schedules.router, prefix="/schedules", tags=["schedules"])
+api_router.include_router(
+    permission_requests.router,
+    prefix="/permission-requests",
+    tags=["permission-requests"],
+)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -20,6 +20,7 @@ from app.models.permission_request import (
     PermissionRequestStatus,
     RejectionStage,
 )
+from app.models.notification import Notification
 
 __all__ = [
     "User",
@@ -41,4 +42,5 @@ __all__ = [
     "PermissionRequest",
     "PermissionRequestStatus",
     "RejectionStage",
+    "Notification",
 ]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,4 @@
-from app.models.user import User
+from app.models.user import User, UserRole
 from app.models.employee import Employee
 from app.models.face_embedding import FaceEmbedding
 from app.models.biometric_face_session import BiometricFaceSession
@@ -15,9 +15,15 @@ from app.models.settings import Settings
 from app.models.position import Position
 from app.models.department import Department
 from app.models.location import Location
+from app.models.permission_request import (
+    PermissionRequest,
+    PermissionRequestStatus,
+    RejectionStage,
+)
 
 __all__ = [
     "User",
+    "UserRole",
     "Employee",
     "FaceEmbedding",
     "AttendanceRecord",
@@ -32,4 +38,7 @@ __all__ = [
     "Department",
     "Location",
     "BiometricFaceSession",
+    "PermissionRequest",
+    "PermissionRequestStatus",
+    "RejectionStage",
 ]

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -1,0 +1,31 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class Notification(Base):
+    __tablename__ = "notifications"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=False
+    )
+    title: Mapped[str] = mapped_column(String(200), nullable=False)
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    type: Mapped[str] = mapped_column(String(50), nullable=False)
+    read: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    request_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("permission_requests.id"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False
+    )
+
+    user: Mapped["User"] = relationship("User", foreign_keys=[user_id])

--- a/backend/app/models/permission_request.py
+++ b/backend/app/models/permission_request.py
@@ -1,0 +1,89 @@
+import uuid
+from datetime import datetime
+from enum import Enum as PyEnum
+
+from sqlalchemy import String, Boolean, DateTime, Date, ForeignKey, Enum, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class PermissionRequestStatus(str, PyEnum):
+    pending              = "pending"
+    coordinator_approved = "coordinator_approved"
+    approved             = "approved"
+    rejected             = "rejected"
+
+
+class RejectionStage(str, PyEnum):
+    coordinator = "coordinator"
+    director    = "director"
+
+
+class PermissionRequest(Base):
+    __tablename__ = "permission_requests"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+
+    # Who requested and for which employee
+    requested_by_user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=False
+    )
+    employee_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("employees.id"), nullable=False
+    )
+
+    # Request details
+    exception_type: Mapped[str] = mapped_column(String, nullable=False)
+    start_date: Mapped[datetime] = mapped_column(Date, nullable=False)
+    end_date: Mapped[datetime] = mapped_column(Date, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Status
+    status: Mapped[PermissionRequestStatus] = mapped_column(
+        Enum(PermissionRequestStatus),
+        nullable=False,
+        default=PermissionRequestStatus.pending,
+    )
+
+    # Coordinator review
+    coordinator_reviewed_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
+    coordinator_reviewed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    coordinator_notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Director review
+    director_reviewed_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=True
+    )
+    director_reviewed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    director_notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Rejection
+    rejection_stage: Mapped[RejectionStage | None] = mapped_column(
+        Enum(RejectionStage), nullable=True
+    )
+    rejection_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Link to created exception when approved
+    schedule_exception_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("schedule_exceptions.id"), nullable=True
+    )
+
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    # Relationships
+    requested_by: Mapped["User"] = relationship(
+        "User", foreign_keys=[requested_by_user_id]
+    )
+    employee: Mapped["Employee"] = relationship("Employee")
+    coordinator_reviewer: Mapped["User"] = relationship(
+        "User", foreign_keys=[coordinator_reviewed_by]
+    )
+    director_reviewer: Mapped["User"] = relationship(
+        "User", foreign_keys=[director_reviewed_by]
+    )

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,11 +1,20 @@
 import uuid
+import enum
 from datetime import datetime
 
-from sqlalchemy import String, Boolean, DateTime
+from sqlalchemy import String, Boolean, DateTime, Enum
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.db.base import Base
+
+
+class UserRole(str, enum.Enum):
+    admin       = "admin"
+    director    = "director"
+    coordinador = "coordinador"
+    secretaria  = "secretaria"
+    catedratico = "catedratico"
 
 
 class User(Base):
@@ -17,7 +26,9 @@ class User(Base):
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
     hashed_password: Mapped[str] = mapped_column(String(255), nullable=False)
     full_name: Mapped[str] = mapped_column(String(200), nullable=True)
-    role: Mapped[str] = mapped_column(String(50), nullable=False, default="admin")
+    role: Mapped[UserRole] = mapped_column(
+        Enum(UserRole), nullable=False, default=UserRole.admin
+    )
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     updated_at: Mapped[datetime] = mapped_column(

--- a/backend/app/schemas/attendance.py
+++ b/backend/app/schemas/attendance.py
@@ -1,7 +1,16 @@
-from datetime import datetime, date
+from datetime import datetime, date, timezone
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
+
+
+def _as_utc(dt: datetime | None) -> str | None:
+    """Serialize naive datetime as UTC ISO 8601 with +00:00 offset."""
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.isoformat()
 
 _BASE64_IMAGE_EXAMPLE = "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBg..."
 
@@ -109,8 +118,11 @@ class AttendanceResponse(BaseModel):
     geo_validated: bool = False
     distance_meters: float | None = None
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
+
+    @field_serializer('check_in', 'check_out')
+    def serialize_datetime(self, dt: datetime | None) -> str | None:
+        return _as_utc(dt)
 
 
 class AttendanceRecordResponse(BaseModel):
@@ -134,5 +146,8 @@ class AttendanceRecordResponse(BaseModel):
     geo_validated: bool = False
     created_at: datetime
 
-    class Config:
-        from_attributes = True
+    model_config = ConfigDict(from_attributes=True)
+
+    @field_serializer('check_in', 'check_out', 'created_at')
+    def serialize_datetime(self, dt: datetime | None) -> str | None:
+        return _as_utc(dt)

--- a/backend/app/schemas/location.py
+++ b/backend/app/schemas/location.py
@@ -16,20 +16,6 @@ class LocationBase(BaseModel):
     def default_radius_if_none(cls, v: object) -> object:
         return 50 if v is None else v
 
-    @field_validator("longitude", mode="before")
-    @classmethod
-    def wrap_longitude(cls, v: object) -> object:
-        if isinstance(v, (int, float)):
-            return ((float(v) + 180) % 360 + 360) % 360 - 180
-        return v
-
-    @field_validator("latitude", mode="before")
-    @classmethod
-    def clamp_latitude(cls, v: object) -> object:
-        if isinstance(v, (int, float)):
-            return max(-90.0, min(90.0, float(v)))
-        return v
-
 
 class LocationCreate(LocationBase):
     model_config = ConfigDict(

--- a/backend/app/schemas/location.py
+++ b/backend/app/schemas/location.py
@@ -16,6 +16,20 @@ class LocationBase(BaseModel):
     def default_radius_if_none(cls, v: object) -> object:
         return 50 if v is None else v
 
+    @field_validator("longitude", mode="before")
+    @classmethod
+    def wrap_longitude(cls, v: object) -> object:
+        if isinstance(v, (int, float)):
+            return ((float(v) + 180) % 360 + 360) % 360 - 180
+        return v
+
+    @field_validator("latitude", mode="before")
+    @classmethod
+    def clamp_latitude(cls, v: object) -> object:
+        if isinstance(v, (int, float)):
+            return max(-90.0, min(90.0, float(v)))
+        return v
+
 
 class LocationCreate(LocationBase):
     model_config = ConfigDict(

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class NotificationResponse(BaseModel):
+    id: UUID
+    user_id: UUID
+    title: str
+    message: str
+    type: str
+    read: bool
+    request_id: UUID | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/app/schemas/permission_request.py
+++ b/backend/app/schemas/permission_request.py
@@ -1,0 +1,55 @@
+from datetime import date, datetime
+from uuid import UUID
+
+from pydantic import BaseModel, field_validator
+
+from app.models.permission_request import PermissionRequestStatus, RejectionStage
+
+
+class PermissionRequestCreate(BaseModel):
+    employee_id: UUID
+    exception_type: str
+    start_date: date
+    end_date: date
+    description: str | None = None
+
+    @field_validator("start_date")
+    @classmethod
+    def validate_min_advance(cls, v: date) -> date:
+        from datetime import date as date_type
+        today = date_type.today()
+        delta = (v - today).days
+        if delta < 7:
+            raise ValueError("La solicitud debe realizarse con al menos 7 días de anticipación")
+        return v
+
+
+class PermissionRequestApprove(BaseModel):
+    notes: str | None = None
+
+
+class PermissionRequestReject(BaseModel):
+    rejection_reason: str  # required
+
+
+class PermissionRequestResponse(BaseModel):
+    id: UUID
+    requested_by_user_id: UUID
+    employee_id: UUID
+    exception_type: str
+    start_date: date
+    end_date: date
+    description: str | None
+    status: PermissionRequestStatus
+    coordinator_reviewed_by: UUID | None
+    coordinator_reviewed_at: datetime | None
+    coordinator_notes: str | None
+    director_reviewed_by: UUID | None
+    director_reviewed_at: datetime | None
+    director_notes: str | None
+    rejection_stage: RejectionStage | None
+    rejection_reason: str | None
+    schedule_exception_id: UUID | None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, field_validator
 
 
 class UserBase(BaseModel):
@@ -12,6 +12,13 @@ class UserBase(BaseModel):
 
 class UserCreate(UserBase):
     password: str
+
+    @field_validator("email")
+    @classmethod
+    def validate_umg_email(cls, v: str) -> str:
+        if not v.endswith("@miumg.edu.gt"):
+            raise ValueError("Solo se aceptan correos institucionales @miumg.edu.gt")
+        return v
 
 
 class UserResponse(UserBase):

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -3,11 +3,13 @@ from uuid import UUID
 
 from pydantic import BaseModel, EmailStr, field_validator
 
+from app.models.user import UserRole
+
 
 class UserBase(BaseModel):
     email: EmailStr
     full_name: str | None = None
-    role: str = "admin"
+    role: UserRole = UserRole.admin
 
 
 class UserCreate(UserBase):

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -1,0 +1,85 @@
+import asyncio
+from datetime import datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.notification import Notification
+from app.services.websocket_manager import ws_manager
+
+
+async def notify_user(
+    db: AsyncSession,
+    user_id: str,
+    title: str,
+    message: str,
+    notification_type: str,
+    request_id: str | None = None,
+) -> None:
+    """
+    Save notification to DB and push via WebSocket if user is connected.
+    Also sends email (fire-and-forget — never blocks the main flow).
+
+    Uses db.flush() to get the generated id without committing.
+    The calling endpoint owns the transaction and must call db.commit().
+    """
+    # 1. Save to DB (flush only — caller commits)
+    notif = Notification(
+        user_id=user_id,
+        title=title,
+        message=message,
+        type=notification_type,
+        request_id=request_id,
+    )
+    db.add(notif)
+    await db.flush()  # get the id without committing
+
+    # 2. Push via WebSocket (fire-and-forget)
+    payload = {
+        "id": str(notif.id),
+        "title": title,
+        "message": message,
+        "type": notification_type,
+        "request_id": str(request_id) if request_id else None,
+        "created_at": datetime.utcnow().isoformat(),
+    }
+    asyncio.create_task(ws_manager.send_to_user(str(user_id), payload))
+
+    # 3. Email (fire-and-forget — import deferred to avoid circular imports)
+    asyncio.create_task(_send_email_notification(user_id, title, message, db))
+
+
+async def _send_email_notification(
+    user_id: str,
+    title: str,
+    message: str,
+    db: AsyncSession,
+) -> None:
+    """Send email via Resend. Silently fails if not configured or on any error."""
+    try:
+        from sqlalchemy import select
+
+        import resend
+
+        from app.core.config import get_settings
+        from app.models.user import User
+
+        settings = get_settings()
+        if not settings.resend_api_key:
+            return
+
+        result = await db.execute(select(User).where(User.id == user_id))
+        user = result.scalar_one_or_none()
+        if not user or not user.email:
+            return
+
+        resend.api_key = settings.resend_api_key
+        resend.Emails.send(
+            {
+                "from": f"{settings.email_from_name} <{settings.email_from}>",
+                "to": user.email,
+                "subject": title,
+                "html": f"<p>{message}</p><br><small>Sistema Biométrico UMG</small>",
+            }
+        )
+    except Exception:
+        pass  # Never block the main flow for email failures

--- a/backend/app/services/websocket_manager.py
+++ b/backend/app/services/websocket_manager.py
@@ -1,0 +1,41 @@
+from fastapi import WebSocket
+
+
+class ConnectionManager:
+    def __init__(self) -> None:
+        # user_id (str) → list of active WebSocket connections
+        self._connections: dict[str, list[WebSocket]] = {}
+
+    async def connect(self, websocket: WebSocket, user_id: str) -> None:
+        await websocket.accept()
+        if user_id not in self._connections:
+            self._connections[user_id] = []
+        self._connections[user_id].append(websocket)
+
+    def disconnect(self, websocket: WebSocket, user_id: str) -> None:
+        if user_id in self._connections:
+            try:
+                self._connections[user_id].remove(websocket)
+            except ValueError:
+                pass
+            if not self._connections[user_id]:
+                del self._connections[user_id]
+
+    async def send_to_user(self, user_id: str, payload: dict) -> None:
+        """Send JSON payload to all connections for a user. Silently ignores if not connected."""
+        connections = self._connections.get(str(user_id), [])
+        dead: list[WebSocket] = []
+        for ws in connections:
+            try:
+                await ws.send_json(payload)
+            except Exception:
+                dead.append(ws)
+        for ws in dead:
+            self.disconnect(ws, str(user_id))
+
+    def is_connected(self, user_id: str) -> bool:
+        return str(user_id) in self._connections
+
+
+# Singleton instance
+ws_manager = ConnectionManager()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -23,6 +23,10 @@ face-recognition>=1.3.0
 numpy>=1.26.0
 pillow>=10.0.0
 
+# Notifications
+resend>=2.0.0
+pywebpush>=2.0.0
+
 # Utils
 python-dotenv>=1.0.0
 setuptools>=70.0.0  # Required for face_recognition_models in Python 3.12+

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,6 +10,7 @@ COPY package*.json ./
 RUN npm ci --prefer-offline --legacy-peer-deps
 
 COPY . .
+ARG CACHEBUST=1
 RUN npm run build -- --configuration production
 
 ## Stage 2 — Serve with nginx

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,8 +9,8 @@ RUN apk add --no-cache python3 make g++
 COPY package*.json ./
 RUN npm ci --prefer-offline --legacy-peer-deps
 
+ARG CACHEBUST=2
 COPY . .
-ARG CACHEBUST=1
 RUN npm run build -- --configuration production
 
 ## Stage 2 — Serve with nginx

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -71,8 +71,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "4kB",
-                  "maximumError": "8kB"
+                  "maximumWarning": "8kB",
+                  "maximumError": "16kB"
                 }
               ],
               "outputHashing": "all",

--- a/frontend/src/app/core/models/schedule.model.ts
+++ b/frontend/src/app/core/models/schedule.model.ts
@@ -5,7 +5,7 @@ export interface SchedulePattern {
   description: string | null;
   check_in_time: string; // "08:00:00"
   check_out_time: string; // "17:00:00"
-  grace_minutes: number;
+  tolerance_minutes: number;
   color: string; // hex color like "#4CAF50"
   is_active: boolean;
   created_at: string;
@@ -16,7 +16,7 @@ export interface SchedulePatternCreate {
   description?: string;
   check_in_time: string;
   check_out_time: string;
-  grace_minutes?: number;
+  tolerance_minutes?: number;
   color?: string;
 }
 
@@ -25,7 +25,7 @@ export interface SchedulePatternUpdate {
   description?: string;
   check_in_time?: string;
   check_out_time?: string;
-  grace_minutes?: number;
+  tolerance_minutes?: number;
   color?: string;
   is_active?: boolean;
 }

--- a/frontend/src/app/features/admin/pages/attendance/attendance.component.ts
+++ b/frontend/src/app/features/admin/pages/attendance/attendance.component.ts
@@ -182,7 +182,8 @@ interface AttendanceSummary {
               <button class="clear-btn" (click)="clearFilters()">Limpiar filtros</button>
             </div>
           } @else {
-            <table>
+            <!-- Desktop table -->
+            <table class="desktop-table">
               <thead>
                 <tr>
                   <th>Empleado</th>
@@ -251,6 +252,56 @@ interface AttendanceSummary {
                 }
               </tbody>
             </table>
+
+            <!-- Mobile cards (visible only on <=480px) -->
+            <div class="mobile-cards">
+              @for (record of filteredAttendance(); track record.id) {
+                <div class="mobile-record-card">
+                  <div class="mobile-card-header">
+                    <span class="employee-name">{{ record.employee_name }}</span>
+                    <span class="status-badge" [class]="record.status">
+                      {{ getStatusLabel(record.status) }}
+                    </span>
+                  </div>
+                  <div class="mobile-card-body">
+                    <div class="mobile-field">
+                      <span class="mobile-label">Fecha</span>
+                      <span class="mobile-value">{{ record.record_date | date: 'dd/MM/yyyy' }}</span>
+                    </div>
+                    <div class="mobile-field">
+                      <span class="mobile-label">Entrada</span>
+                      <span class="mobile-value">
+                        @if (record.check_in) {
+                          <span class="time-badge check-in">{{ record.check_in | date: 'HH:mm' }}</span>
+                        } @else {
+                          <span class="time-badge no-time">-</span>
+                        }
+                      </span>
+                    </div>
+                    <div class="mobile-field">
+                      <span class="mobile-label">Salida</span>
+                      <span class="mobile-value">
+                        @if (record.check_out) {
+                          <span class="time-badge check-out">{{ record.check_out | date: 'HH:mm' }}</span>
+                        } @else {
+                          <span class="time-badge no-time">-</span>
+                        }
+                      </span>
+                    </div>
+                    <div class="mobile-field">
+                      <span class="mobile-label">Horas</span>
+                      <span class="mobile-value hours-worked">{{ calculateHoursWorked(record) }}</span>
+                    </div>
+                    @if (record.confidence) {
+                      <div class="mobile-field">
+                        <span class="mobile-label">Confianza</span>
+                        <span class="mobile-value">{{ (record.confidence * 100) | number: '1.0-0' }}%</span>
+                      </div>
+                    }
+                  </div>
+                </div>
+              }
+            </div>
           }
         </div>
       </section>
@@ -321,6 +372,7 @@ interface AttendanceSummary {
       font-weight: 500;
       cursor: pointer;
       transition: all 0.2s;
+      white-space: nowrap;
     }
 
     .export-btn:hover:not(:disabled) {
@@ -715,6 +767,54 @@ interface AttendanceSummary {
       color: #9ca3af;
     }
 
+    /* Mobile cards — hidden on desktop */
+    .mobile-cards {
+      display: none;
+    }
+
+    .mobile-record-card {
+      border: 1px solid #e5e7eb;
+      border-radius: 0.75rem;
+      overflow: hidden;
+    }
+
+    .mobile-card-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.75rem 1rem;
+      background: #f9fafb;
+      border-bottom: 1px solid #e5e7eb;
+      gap: 0.5rem;
+    }
+
+    .mobile-card-body {
+      padding: 0.75rem 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .mobile-field {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-size: 0.875rem;
+    }
+
+    .mobile-label {
+      color: #6b7280;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.025em;
+    }
+
+    .mobile-value {
+      color: #1f2937;
+      font-weight: 500;
+    }
+
     /* Responsive */
     @media (max-width: 1200px) {
       .summary-cards {
@@ -754,7 +854,7 @@ interface AttendanceSummary {
       }
 
       .filters-grid {
-        grid-template-columns: 1fr;
+        grid-template-columns: repeat(2, 1fr);
       }
 
       .table-container {
@@ -766,9 +866,47 @@ interface AttendanceSummary {
       }
     }
 
+    @media (max-width: 600px) {
+      .filters-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .summary-cards {
+        grid-template-columns: repeat(2, 1fr);
+      }
+    }
+
     @media (max-width: 480px) {
+      .attendance-page {
+        padding: 0.75rem;
+      }
+
       .summary-cards {
         grid-template-columns: 1fr;
+      }
+
+      .card {
+        padding: 0.875rem;
+      }
+
+      /* Hide table, show cards */
+      .desktop-table {
+        display: none;
+      }
+
+      .mobile-cards {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        padding: 0.75rem;
+      }
+
+      .table-header {
+        padding: 0.75rem 1rem;
+      }
+
+      .table-header h2 {
+        font-size: 1rem;
       }
     }
   `],

--- a/frontend/src/app/features/admin/pages/dashboard/dashboard.component.ts
+++ b/frontend/src/app/features/admin/pages/dashboard/dashboard.component.ts
@@ -316,6 +316,92 @@ import { Employee } from '../../../../core/models/employee.model';
     .status.present { background: #dcfce7; color: #166534; }
     .status.late { background: #fef3c7; color: #92400e; }
     .status.absent { background: #fee2e2; color: #991b1b; }
+
+    /* Responsive */
+    @media (max-width: 768px) {
+      .dashboard {
+        padding: 1rem;
+      }
+
+      .header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1rem;
+        margin-bottom: 1.5rem;
+      }
+
+      .header-right {
+        width: 100%;
+        flex-wrap: wrap;
+      }
+
+      .header-right .btn {
+        flex: 1;
+        text-align: center;
+        justify-content: center;
+      }
+
+      .header h1 {
+        font-size: 1.5rem;
+      }
+
+      .nav-cards {
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 1rem;
+      }
+
+      .nav-card {
+        padding: 1rem;
+      }
+
+      .nav-icon {
+        font-size: 1.5rem;
+        margin-bottom: 0.5rem;
+      }
+    }
+
+    @media (max-width: 600px) {
+      .stats-grid {
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 1rem;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .dashboard {
+        padding: 0.75rem;
+      }
+
+      .header h1 {
+        font-size: 1.25rem;
+      }
+
+      .nav-cards {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 0.75rem;
+      }
+
+      .nav-card {
+        padding: 0.875rem;
+      }
+
+      .nav-card p {
+        display: none;
+      }
+
+      .stat-card {
+        padding: 1rem;
+      }
+
+      .stat-value {
+        font-size: 1.25rem;
+      }
+
+      th, td {
+        padding: 0.5rem;
+        font-size: 0.8125rem;
+      }
+    }
   `],
 })
 export class DashboardComponent implements OnInit {

--- a/frontend/src/app/features/admin/pages/employees/employees.component.ts
+++ b/frontend/src/app/features/admin/pages/employees/employees.component.ts
@@ -29,9 +29,9 @@ import { Location } from '../../../../core/models/location.model';
         </button>
       </header>
 
-      <!-- Employees table -->
+      <!-- Desktop table -->
       <div class="table-container">
-        <table>
+        <table class="desktop-table">
           <thead>
             <tr>
               <th>Código</th>
@@ -90,6 +90,67 @@ import { Location } from '../../../../core/models/location.model';
             }
           </tbody>
         </table>
+
+        <!-- Mobile cards (visible only on <=480px) -->
+        <div class="mobile-cards">
+          @for (employee of employees(); track employee.id) {
+            <div class="mobile-employee-card">
+              <div class="mobile-card-header">
+                <div class="mobile-card-title">
+                  <span class="mobile-emp-code">{{ employee.employee_code }}</span>
+                  <span class="mobile-emp-name">{{ employee.first_name }} {{ employee.last_name }}</span>
+                </div>
+                @if (employee.has_face_registered) {
+                  <span class="badge success">Registrado</span>
+                } @else {
+                  <span class="badge warning">Pendiente</span>
+                }
+              </div>
+              <div class="mobile-card-body">
+                <div class="mobile-field">
+                  <span class="mobile-label">Email</span>
+                  <span class="mobile-value mobile-email">{{ employee.email }}</span>
+                </div>
+                <div class="mobile-field">
+                  <span class="mobile-label">Departamento</span>
+                  <span class="mobile-value">{{ getDepartmentName(employee.department_id) }}</span>
+                </div>
+                <div class="mobile-field">
+                  <span class="mobile-label">Puesto</span>
+                  <span class="mobile-value">{{ getPositionName(employee.position_id) }}</span>
+                </div>
+                <div class="mobile-field">
+                  <span class="mobile-label">Sede</span>
+                  <span class="mobile-value">{{ getLocationName(employee.location_id) }}</span>
+                </div>
+              </div>
+              <div class="mobile-card-actions">
+                <button
+                  class="btn btn-sm btn-edit"
+                  (click)="editEmployee(employee)"
+                  title="Editar"
+                >
+                  ✏️ Editar
+                </button>
+                <button
+                  class="btn btn-sm"
+                  (click)="registerFace(employee)"
+                  [disabled]="employee.has_face_registered"
+                  title="Registrar rostro"
+                >
+                  📷 Rostro
+                </button>
+                <button
+                  class="btn btn-sm btn-danger"
+                  (click)="deleteEmployee(employee)"
+                  title="Eliminar"
+                >
+                  🗑️
+                </button>
+              </div>
+            </div>
+          }
+        </div>
       </div>
 
       <!-- Create/Edit modal -->
@@ -342,6 +403,8 @@ import { Location } from '../../../../core/models/location.model';
       justify-content: space-between;
       align-items: flex-end;
       margin-bottom: 2rem;
+      flex-wrap: wrap;
+      gap: 1rem;
     }
 
     .back-link {
@@ -390,6 +453,87 @@ import { Location } from '../../../../core/models/location.model';
 
     .actions { display: flex; gap: 0.5rem; }
 
+    /* Mobile cards — hidden on desktop */
+    .mobile-cards {
+      display: none;
+    }
+
+    .mobile-employee-card {
+      border-bottom: 1px solid #e5e7eb;
+      padding: 1rem;
+    }
+
+    .mobile-employee-card:last-child {
+      border-bottom: none;
+    }
+
+    .mobile-card-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 0.75rem;
+      gap: 0.5rem;
+    }
+
+    .mobile-card-title {
+      display: flex;
+      flex-direction: column;
+      gap: 0.125rem;
+    }
+
+    .mobile-emp-code {
+      font-size: 0.75rem;
+      color: #6b7280;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .mobile-emp-name {
+      font-size: 1rem;
+      font-weight: 600;
+      color: #1f2937;
+    }
+
+    .mobile-card-body {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .mobile-field {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-size: 0.875rem;
+    }
+
+    .mobile-label {
+      color: #6b7280;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.025em;
+      flex-shrink: 0;
+    }
+
+    .mobile-value {
+      color: #374151;
+      text-align: right;
+    }
+
+    .mobile-email {
+      font-size: 0.8125rem;
+      word-break: break-all;
+    }
+
+    .mobile-card-actions {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: flex-end;
+    }
+
     .modal-overlay {
       position: fixed;
       inset: 0;
@@ -398,6 +542,7 @@ import { Location } from '../../../../core/models/location.model';
       align-items: center;
       justify-content: center;
       z-index: 50;
+      padding: 1rem;
     }
 
     .modal {
@@ -694,6 +839,83 @@ import { Location } from '../../../../core/models/location.model';
     .bio-btn--confirm:hover:not(:disabled) { background: #16a34a; box-shadow: 0 0 16px rgba(22,163,74,0.5); }
     .spin { animation: spin 1s linear infinite; }
     @keyframes spin { from{transform:rotate(0deg)} to{transform:rotate(360deg)} }
+
+    /* Responsive */
+    @media (max-width: 768px) {
+      .employees-page {
+        padding: 1rem;
+      }
+
+      .header {
+        align-items: flex-start;
+      }
+
+      h1 {
+        font-size: 1.5rem;
+      }
+
+      th, td {
+        padding: 0.75rem 0.625rem;
+        font-size: 0.875rem;
+      }
+    }
+
+    @media (max-width: 600px) {
+      .form-row {
+        grid-template-columns: 1fr;
+      }
+
+      .modal {
+        padding: 1.25rem;
+      }
+
+      .bio-panel {
+        padding: 1.25rem;
+      }
+
+      .bio-thumb img,
+      .bio-thumb__empty {
+        width: 56px;
+        height: 56px;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .employees-page {
+        padding: 0.75rem;
+      }
+
+      /* Hide table, show cards */
+      .desktop-table {
+        display: none;
+      }
+
+      .mobile-cards {
+        display: block;
+      }
+
+      .modal {
+        padding: 1rem;
+      }
+
+      .modal-actions {
+        flex-direction: column-reverse;
+      }
+
+      .modal-actions .btn {
+        width: 100%;
+        text-align: center;
+      }
+
+      .bio-actions {
+        flex-wrap: wrap;
+      }
+
+      .bio-btn {
+        flex: 1;
+        justify-content: center;
+      }
+    }
   `],
 })
 export class EmployeesComponent implements OnInit {

--- a/frontend/src/app/features/admin/pages/employees/employees.component.ts
+++ b/frontend/src/app/features/admin/pages/employees/employees.component.ts
@@ -405,7 +405,7 @@ import { Location } from '../../../../core/models/location.model';
       padding: 2rem;
       border-radius: 1rem;
       width: 100%;
-      max-width: 550px;
+      max-width: 720px;
       max-height: 90vh;
       overflow-y: auto;
     }

--- a/frontend/src/app/features/admin/pages/locations/locations.component.ts
+++ b/frontend/src/app/features/admin/pages/locations/locations.component.ts
@@ -340,6 +340,80 @@ import { Location, LocationCreate } from '../../../../core/models/location.model
       gap: 0.75rem;
       margin-top: 1.5rem;
     }
+
+    /* Responsive */
+    @media (max-width: 768px) {
+      .locations-page {
+        padding: 1rem;
+      }
+
+      .header {
+        flex-wrap: wrap;
+        gap: 1rem;
+        align-items: flex-start;
+      }
+
+      h1 {
+        font-size: 1.5rem;
+      }
+
+      .content {
+        grid-template-columns: 1fr;
+        height: auto;
+      }
+
+      .map-container {
+        min-height: 300px;
+        height: 300px;
+      }
+
+      #map {
+        min-height: 300px;
+        height: 300px;
+      }
+    }
+
+    @media (max-width: 600px) {
+      .card-actions {
+        gap: 0.5rem;
+      }
+
+      .form-row {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .locations-page {
+        padding: 0.75rem;
+      }
+
+      .header {
+        margin-bottom: 1rem;
+      }
+
+      h1 {
+        font-size: 1.25rem;
+        margin-top: 0.25rem;
+      }
+
+      .modal {
+        padding: 1.25rem;
+      }
+
+      .modal-actions {
+        flex-direction: column-reverse;
+      }
+
+      .modal-actions .btn {
+        width: 100%;
+        text-align: center;
+      }
+
+      .location-card {
+        padding: 0.875rem;
+      }
+    }
   `],
 })
 export class LocationsComponent implements OnInit, AfterViewInit {

--- a/frontend/src/app/features/admin/pages/locations/locations.component.ts
+++ b/frontend/src/app/features/admin/pages/locations/locations.component.ts
@@ -487,14 +487,15 @@ export class LocationsComponent implements OnInit, AfterViewInit {
     }).addTo(this.modalMap);
 
     this.modalMarker.on('dragend', () => {
-      const pos = this.modalMarker!.getLatLng();
+      const pos = this.modalMarker!.getLatLng().wrap();
       this.formData.latitude = Math.round(pos.lat * 1000000) / 1000000;
       this.formData.longitude = Math.round(pos.lng * 1000000) / 1000000;
     });
 
     this.modalMap.on('click', (e: L.LeafletMouseEvent) => {
-      this.formData.latitude = Math.round(e.latlng.lat * 1000000) / 1000000;
-      this.formData.longitude = Math.round(e.latlng.lng * 1000000) / 1000000;
+      const pos = e.latlng.wrap();
+      this.formData.latitude = Math.round(pos.lat * 1000000) / 1000000;
+      this.formData.longitude = Math.round(pos.lng * 1000000) / 1000000;
       this.modalMarker?.setLatLng(e.latlng);
     });
   }

--- a/frontend/src/app/features/admin/pages/schedules/schedules.component.ts
+++ b/frontend/src/app/features/admin/pages/schedules/schedules.component.ts
@@ -285,7 +285,7 @@ interface WeekDay {
                   </div>
                   <div class="form-group">
                     <label for="patternGrace">Tolerancia (min)</label>
-                    <input id="patternGrace" type="number" [(ngModel)]="patternForm.grace_minutes" />
+                    <input id="patternGrace" type="number" [(ngModel)]="patternForm.tolerance_minutes" />
                   </div>
                   <div class="form-group full-width">
                     <label for="patternDesc">Descripcion</label>
@@ -1487,7 +1487,7 @@ export class SchedulesComponent implements OnInit {
       description: pattern.description || '',
       check_in_time: this.formatTime(pattern.check_in_time),
       check_out_time: this.formatTime(pattern.check_out_time),
-      grace_minutes: pattern.grace_minutes,
+      tolerance_minutes: pattern.tolerance_minutes,
       color: pattern.color,
     };
   }
@@ -1504,7 +1504,7 @@ export class SchedulesComponent implements OnInit {
       description: this.patternForm.description || undefined,
       check_in_time: this.patternForm.check_in_time + ':00',
       check_out_time: this.patternForm.check_out_time + ':00',
-      grace_minutes: this.patternForm.grace_minutes,
+      tolerance_minutes: this.patternForm.tolerance_minutes,
       color: this.patternForm.color,
     };
 
@@ -1698,7 +1698,7 @@ export class SchedulesComponent implements OnInit {
       description: '',
       check_in_time: '08:00',
       check_out_time: '17:00',
-      grace_minutes: 15,
+      tolerance_minutes: 15,
       color: '#4CAF50',
     };
   }

--- a/frontend/src/app/features/admin/pages/schedules/schedules.component.ts
+++ b/frontend/src/app/features/admin/pages/schedules/schedules.component.ts
@@ -699,7 +699,7 @@ interface WeekDay {
     .calendar-table {
       width: 100%;
       border-collapse: collapse;
-      min-width: 1200px;
+      min-width: 800px;
     }
 
     .calendar-table th,
@@ -1112,16 +1112,23 @@ interface WeekDay {
 
       .header-actions .btn {
         flex: 1;
+        min-width: 120px;
         justify-content: center;
       }
 
       .filters-grid {
-        grid-template-columns: 1fr;
+        grid-template-columns: repeat(2, 1fr);
       }
 
       .week-navigation {
         flex-direction: column;
         gap: 0.75rem;
+        text-align: center;
+      }
+
+      .nav-btn {
+        width: 100%;
+        justify-content: center;
       }
 
       .bulk-actions {
@@ -1140,6 +1147,61 @@ interface WeekDay {
 
       .form-group.full-width {
         grid-column: span 1;
+      }
+    }
+
+    @media (max-width: 600px) {
+      .schedules-page {
+        padding: 0.75rem;
+      }
+
+      .filters-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .header-actions .btn {
+        flex: 1 1 calc(50% - 0.375rem);
+      }
+    }
+
+    @media (max-width: 480px) {
+      .header-actions .btn {
+        flex: 1 1 100%;
+      }
+
+      .calendar-table {
+        min-width: 600px;
+        font-size: 0.75rem;
+      }
+
+      .col-id,
+      .col-department {
+        display: none;
+      }
+
+      .col-name,
+      .col-lastname {
+        width: 90px;
+      }
+
+      .col-pattern {
+        width: 80px;
+      }
+
+      .col-day {
+        min-width: 70px;
+      }
+
+      .schedule-time {
+        font-size: 0.6875rem;
+      }
+
+      .modal {
+        max-width: 100%;
+      }
+
+      .bulk-actions {
+        padding: 0.75rem 1rem;
       }
     }
   `],

--- a/frontend/src/app/features/admin/pages/settings/settings.component.ts
+++ b/frontend/src/app/features/admin/pages/settings/settings.component.ts
@@ -239,6 +239,41 @@ import { Settings, SettingsUpdate } from '../../../../core/models/settings.model
       padding: 2rem;
       color: #6b7280;
     }
+
+    /* Responsive */
+    @media (max-width: 768px) {
+      .settings-page {
+        padding: 1rem;
+      }
+
+      h1 {
+        font-size: 1.5rem;
+      }
+    }
+
+    @media (max-width: 480px) {
+      .settings-page {
+        padding: 0.75rem;
+      }
+
+      h1 {
+        font-size: 1.25rem;
+      }
+
+      .settings-card,
+      .info-card {
+        padding: 1.25rem;
+      }
+
+      .form-actions {
+        margin-top: 1.25rem;
+      }
+
+      .btn {
+        width: 100%;
+        text-align: center;
+      }
+    }
   `],
 })
 export class SettingsComponent implements OnInit {


### PR DESCRIPTION
## Summary
- Adds real-time WebSocket endpoint (`GET /api/v1/ws/notifications?token=<JWT>`) with JWT auth and ping/pong keepalive
- Adds in-app notification center: list, unread count, mark one read, mark all read
- Adds Alembic migration (`e5f6a7b8c9d0`) creating the `notifications` table with FK to `users` and `permission_requests`
- Wires `notify_user` into the permission_requests approve/reject endpoints — fires notifications on coordinator approval, director approval, and rejection

## Architecture notes
- `ws_manager` is a process-local singleton (`ConnectionManager`); supports multiple WebSocket connections per user
- `notify_user` uses `db.flush()` — never calls `db.commit()` so the calling endpoint owns the transaction
- Email via Resend is dispatched as `asyncio.create_task` — failures are silently swallowed, never blocking the HTTP response
- WebSocket auth reuses the existing `decode_token` from `app/core/security.py`; validates `type == "access"` claim

## Test plan
- [ ] Connect WebSocket with valid JWT → connection accepted
- [ ] Connect WebSocket with invalid/expired token → close code 4001
- [ ] Approve a pending request as coordinador → requester receives `permission_coordinator_approved` notification via WebSocket and in `GET /notifications`
- [ ] Approve a coordinator_approved request as director → requester receives `permission_approved` notification
- [ ] Reject a request → requester receives `permission_rejected` notification
- [ ] `GET /notifications/unread-count` returns correct count
- [ ] `PATCH /notifications/{id}/read` marks single notification read
- [ ] `PATCH /notifications/read-all` marks all unread notifications read
- [ ] Run alembic migration: `alembic upgrade head`