### PR TITLE
feat(frontend): permission requests + real-time notifications

### DIFF
--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -31,6 +31,14 @@ export const routes: Routes = [
     ],
   },
   {
+    path: 'requests',
+    canActivate: [authGuard],
+    loadComponent: () =>
+      import('./features/requests/pages/my-requests/my-requests.component').then(
+        (m) => m.MyRequestsComponent
+      ),
+  },
+  {
     path: 'admin',
     canActivate: [authGuard, adminGuard],
     children: [
@@ -93,6 +101,13 @@ export const routes: Routes = [
         loadComponent: () =>
           import('./features/admin/pages/positions/positions.component').then(
             (m) => m.PositionsComponent
+          ),
+      },
+      {
+        path: 'permission-requests',
+        loadComponent: () =>
+          import('./features/admin/pages/permission-requests/permission-requests.component').then(
+            (m) => m.AdminPermissionRequestsComponent
           ),
       },
     ],

--- a/frontend/src/app/core/components/notification-bell/notification-bell.component.ts
+++ b/frontend/src/app/core/components/notification-bell/notification-bell.component.ts
@@ -1,0 +1,293 @@
+import {
+  Component,
+  OnInit,
+  OnDestroy,
+  inject,
+  signal,
+  computed,
+  HostListener,
+  ElementRef,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Subscription } from 'rxjs';
+import { NotificationService } from '../../services/notification.service';
+import { WebSocketNotificationService } from '../../services/websocket-notification.service';
+import { Notification } from '../../models/notification.model';
+
+@Component({
+  selector: 'app-notification-bell',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="bell-wrapper">
+      <button class="bell-btn" (click)="toggleDropdown()" aria-label="Notificaciones">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="22"
+          height="22"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+          <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+        </svg>
+        @if (unreadCount() > 0) {
+          <span class="badge">{{ unreadCount() > 99 ? '99+' : unreadCount() }}</span>
+        }
+      </button>
+
+      @if (open()) {
+        <div class="dropdown">
+          <div class="dropdown-header">
+            <span class="dropdown-title">Notificaciones</span>
+            @if (unreadCount() > 0) {
+              <button class="mark-all-btn" (click)="markAllRead()">
+                Marcar todas como leídas
+              </button>
+            }
+          </div>
+
+          <div class="dropdown-list">
+            @if (notifications().length === 0) {
+              <div class="empty-state">Sin notificaciones</div>
+            }
+            @for (notif of notifications(); track notif.id) {
+              <div
+                class="notif-item"
+                [class.unread]="!notif.read"
+                (click)="markRead(notif)"
+              >
+                <div class="notif-title">{{ notif.title }}</div>
+                <div class="notif-message">{{ notif.message }}</div>
+                <div class="notif-time">{{ timeAgo(notif.created_at) }}</div>
+              </div>
+            }
+          </div>
+        </div>
+      }
+    </div>
+  `,
+  styles: [`
+    .bell-wrapper {
+      position: relative;
+      display: inline-block;
+    }
+
+    .bell-btn {
+      position: relative;
+      background: transparent;
+      border: none;
+      cursor: pointer;
+      padding: 0.5rem;
+      border-radius: 0.5rem;
+      color: #374151;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background 0.2s;
+    }
+
+    .bell-btn:hover {
+      background: #f3f4f6;
+    }
+
+    .badge {
+      position: absolute;
+      top: 2px;
+      right: 2px;
+      background: #ef4444;
+      color: white;
+      font-size: 0.6rem;
+      font-weight: 700;
+      min-width: 16px;
+      height: 16px;
+      border-radius: 9999px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 3px;
+      line-height: 1;
+    }
+
+    .dropdown {
+      position: absolute;
+      top: calc(100% + 8px);
+      right: 0;
+      width: 320px;
+      background: white;
+      border-radius: 0.75rem;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+      z-index: 1000;
+      overflow: hidden;
+    }
+
+    .dropdown-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 0.875rem 1rem;
+      border-bottom: 1px solid #e5e7eb;
+    }
+
+    .dropdown-title {
+      font-weight: 600;
+      color: #1f2937;
+      font-size: 0.9rem;
+    }
+
+    .mark-all-btn {
+      background: none;
+      border: none;
+      color: #3b82f6;
+      font-size: 0.75rem;
+      cursor: pointer;
+      padding: 0;
+    }
+
+    .mark-all-btn:hover {
+      text-decoration: underline;
+    }
+
+    .dropdown-list {
+      max-height: 360px;
+      overflow-y: auto;
+    }
+
+    .empty-state {
+      padding: 2rem;
+      text-align: center;
+      color: #9ca3af;
+      font-size: 0.875rem;
+    }
+
+    .notif-item {
+      padding: 0.875rem 1rem;
+      border-bottom: 1px solid #f3f4f6;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+
+    .notif-item:last-child {
+      border-bottom: none;
+    }
+
+    .notif-item:hover {
+      background: #f9fafb;
+    }
+
+    .notif-item.unread {
+      background: #eff6ff;
+    }
+
+    .notif-item.unread:hover {
+      background: #dbeafe;
+    }
+
+    .notif-title {
+      font-weight: 600;
+      color: #1f2937;
+      font-size: 0.875rem;
+      margin-bottom: 0.25rem;
+    }
+
+    .notif-message {
+      color: #6b7280;
+      font-size: 0.8rem;
+      margin-bottom: 0.25rem;
+      line-height: 1.4;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+
+    .notif-time {
+      color: #9ca3af;
+      font-size: 0.7rem;
+    }
+
+    @media (max-width: 480px) {
+      .dropdown {
+        width: 280px;
+        right: -8px;
+      }
+    }
+  `],
+})
+export class NotificationBellComponent implements OnInit, OnDestroy {
+  private readonly notifService = inject(NotificationService);
+  private readonly wsService = inject(WebSocketNotificationService);
+  private readonly elRef = inject(ElementRef);
+
+  readonly notifications = signal<Notification[]>([]);
+  readonly open = signal(false);
+
+  readonly unreadCount = computed(
+    () => this.notifications().filter((n) => !n.read).length
+  );
+
+  private sub: Subscription | null = null;
+
+  ngOnInit(): void {
+    this.loadNotifications();
+
+    this.sub = this.wsService.notifications$.subscribe((incoming) => {
+      this.notifications.update((list) => [incoming, ...list].slice(0, 50));
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.sub?.unsubscribe();
+  }
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: Event): void {
+    if (!this.elRef.nativeElement.contains(event.target)) {
+      this.open.set(false);
+    }
+  }
+
+  toggleDropdown(): void {
+    this.open.update((v) => !v);
+    if (this.open()) {
+      this.loadNotifications();
+    }
+  }
+
+  markRead(notif: Notification): void {
+    if (notif.read) return;
+    this.notifService.markRead(notif.id).subscribe(() => {
+      this.notifications.update((list) =>
+        list.map((n) => (n.id === notif.id ? { ...n, read: true } : n))
+      );
+    });
+  }
+
+  markAllRead(): void {
+    this.notifService.markAllRead().subscribe(() => {
+      this.notifications.update((list) => list.map((n) => ({ ...n, read: true })));
+    });
+  }
+
+  timeAgo(dateStr: string): string {
+    const diff = Date.now() - new Date(dateStr).getTime();
+    const mins = Math.floor(diff / 60_000);
+    if (mins < 1) return 'ahora';
+    if (mins < 60) return `hace ${mins} min`;
+    const hrs = Math.floor(mins / 60);
+    if (hrs < 24) return `hace ${hrs} h`;
+    const days = Math.floor(hrs / 24);
+    return `hace ${days} d`;
+  }
+
+  private loadNotifications(): void {
+    this.notifService.getAll().subscribe({
+      next: (list) => this.notifications.set(list.slice(0, 20)),
+      error: () => {},
+    });
+  }
+}

--- a/frontend/src/app/core/models/notification.model.ts
+++ b/frontend/src/app/core/models/notification.model.ts
@@ -1,0 +1,14 @@
+export interface Notification {
+  id: string;
+  user_id: string;
+  title: string;
+  message: string;
+  type: string;
+  read: boolean;
+  request_id: string | null;
+  created_at: string;
+}
+
+export interface UnreadCountResponse {
+  count: number;
+}

--- a/frontend/src/app/core/models/permission-request.model.ts
+++ b/frontend/src/app/core/models/permission-request.model.ts
@@ -1,0 +1,64 @@
+export type PermissionRequestStatus =
+  | 'pending'
+  | 'coordinator_approved'
+  | 'approved'
+  | 'rejected';
+
+export type RejectionStage = 'coordinator' | 'director';
+
+export interface PermissionRequest {
+  id: string;
+  requested_by_user_id: string;
+  employee_id: string;
+  exception_type: string;
+  start_date: string;
+  end_date: string;
+  description: string | null;
+  status: PermissionRequestStatus;
+  coordinator_reviewed_by: string | null;
+  coordinator_reviewed_at: string | null;
+  coordinator_notes: string | null;
+  director_reviewed_by: string | null;
+  director_reviewed_at: string | null;
+  director_notes: string | null;
+  rejection_stage: RejectionStage | null;
+  rejection_reason: string | null;
+  schedule_exception_id: string | null;
+  created_at: string;
+  // enriched fields (may be populated by backend or resolved client-side)
+  employee_name?: string;
+}
+
+export interface PermissionRequestCreate {
+  employee_id: string;
+  exception_type: string;
+  start_date: string;
+  end_date: string;
+  description?: string;
+}
+
+export interface PermissionRequestFilters {
+  status?: PermissionRequestStatus;
+  employee_id?: string;
+}
+
+export const STATUS_LABELS: Record<PermissionRequestStatus, string> = {
+  pending: 'Pendiente',
+  coordinator_approved: 'Aprobado por Coordinador',
+  approved: 'Aprobado',
+  rejected: 'Rechazado',
+};
+
+export const STATUS_COLORS: Record<PermissionRequestStatus, string> = {
+  pending: '#F59E0B',
+  coordinator_approved: '#3B82F6',
+  approved: '#10B981',
+  rejected: '#EF4444',
+};
+
+export const STATUS_BG_CLASSES: Record<PermissionRequestStatus, string> = {
+  pending: 'badge-pending',
+  coordinator_approved: 'badge-coordinator',
+  approved: 'badge-approved',
+  rejected: 'badge-rejected',
+};

--- a/frontend/src/app/core/models/user.model.ts
+++ b/frontend/src/app/core/models/user.model.ts
@@ -7,7 +7,13 @@ export interface User {
   created_at: string;
 }
 
-export type UserRole = 'admin' | 'supervisor';
+export type UserRole =
+  | 'admin'
+  | 'director'
+  | 'coordinador'
+  | 'secretaria'
+  | 'catedratico'
+  | 'supervisor'; // legacy — keep for backward compat
 
 export interface LoginRequest {
   username: string;

--- a/frontend/src/app/core/services/auth.service.ts
+++ b/frontend/src/app/core/services/auth.service.ts
@@ -1,9 +1,10 @@
 import { Injectable, inject, signal, computed } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
-import { Observable, tap, catchError, of, throwError } from 'rxjs';
+import { Observable, tap, catchError, throwError } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { User, LoginRequest, TokenResponse } from '../models/user.model';
+import { WebSocketNotificationService } from './websocket-notification.service';
 
 const ACCESS_TOKEN_KEY = 'access_token';
 const REFRESH_TOKEN_KEY = 'refresh_token';
@@ -14,6 +15,7 @@ const REFRESH_TOKEN_KEY = 'refresh_token';
 export class AuthService {
   private readonly http = inject(HttpClient);
   private readonly router = inject(Router);
+  private readonly wsNotif = inject(WebSocketNotificationService);
   private readonly baseUrl = environment.apiUrl;
 
   private readonly currentUser = signal<User | null>(null);
@@ -23,6 +25,7 @@ export class AuthService {
   readonly loading = this.isLoading.asReadonly();
   readonly isAuthenticated = computed(() => !!this.currentUser());
   readonly isAdmin = computed(() => this.currentUser()?.role === 'admin');
+  readonly isCoordinadorOrAbove = computed(() => ['admin', 'director', 'coordinador'].includes(this.currentUser()?.role ?? ''));
 
   constructor() {
     this.loadCurrentUser();
@@ -42,6 +45,7 @@ export class AuthService {
         tap((response) => {
           this.setTokens(response);
           this.loadCurrentUser();
+          this.wsNotif.connect(response.access_token);
         }),
         catchError((error) => {
           this.isLoading.set(false);
@@ -51,6 +55,7 @@ export class AuthService {
   }
 
   logout(): void {
+    this.wsNotif.disconnect();
     this.clearTokens();
     this.currentUser.set(null);
     this.router.navigate(['/auth/login']);
@@ -92,6 +97,8 @@ export class AuthService {
       next: (user) => {
         this.currentUser.set(user);
         this.isLoading.set(false);
+        // Reconnect WebSocket when user is loaded from stored token
+        this.wsNotif.connect(token);
       },
       error: () => {
         this.clearTokens();

--- a/frontend/src/app/core/services/notification.service.ts
+++ b/frontend/src/app/core/services/notification.service.ts
@@ -1,0 +1,27 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService } from './api.service';
+import { Notification, UnreadCountResponse } from '../models/notification.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class NotificationService {
+  private readonly api = inject(ApiService);
+
+  getAll(): Observable<Notification[]> {
+    return this.api.get<Notification[]>('/notifications');
+  }
+
+  getUnreadCount(): Observable<UnreadCountResponse> {
+    return this.api.get<UnreadCountResponse>('/notifications/unread-count');
+  }
+
+  markRead(id: string): Observable<Notification> {
+    return this.api.patch<Notification>(`/notifications/${id}/read`, {});
+  }
+
+  markAllRead(): Observable<void> {
+    return this.api.patch<void>('/notifications/read-all', {});
+  }
+}

--- a/frontend/src/app/core/services/permission-request.service.ts
+++ b/frontend/src/app/core/services/permission-request.service.ts
@@ -1,0 +1,46 @@
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiService } from './api.service';
+import {
+  PermissionRequest,
+  PermissionRequestCreate,
+  PermissionRequestFilters,
+} from '../models/permission-request.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PermissionRequestService {
+  private readonly api = inject(ApiService);
+
+  getAll(filters?: PermissionRequestFilters): Observable<PermissionRequest[]> {
+    return this.api.get<PermissionRequest[]>(
+      '/permission-requests',
+      filters as Record<string, string>
+    );
+  }
+
+  getById(id: string): Observable<PermissionRequest> {
+    return this.api.get<PermissionRequest>(`/permission-requests/${id}`);
+  }
+
+  create(payload: PermissionRequestCreate): Observable<PermissionRequest> {
+    return this.api.post<PermissionRequest>('/permission-requests', payload);
+  }
+
+  approve(id: string, notes?: string): Observable<PermissionRequest> {
+    return this.api.patch<PermissionRequest>(`/permission-requests/${id}/approve`, {
+      notes: notes ?? null,
+    });
+  }
+
+  reject(id: string, rejection_reason: string): Observable<PermissionRequest> {
+    return this.api.patch<PermissionRequest>(`/permission-requests/${id}/reject`, {
+      rejection_reason,
+    });
+  }
+
+  delete(id: string): Observable<void> {
+    return this.api.delete<void>(`/permission-requests/${id}`);
+  }
+}

--- a/frontend/src/app/core/services/websocket-notification.service.ts
+++ b/frontend/src/app/core/services/websocket-notification.service.ts
@@ -1,0 +1,104 @@
+import { Injectable } from '@angular/core';
+import { Subject, Observable } from 'rxjs';
+import { Notification } from '../models/notification.model';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class WebSocketNotificationService {
+  private socket: WebSocket | null = null;
+  private readonly notificationsSubject = new Subject<Notification>();
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private pingTimer: ReturnType<typeof setInterval> | null = null;
+  private retryCount = 0;
+  private readonly maxRetryDelay = 30_000;
+  private currentToken: string | null = null;
+  private intentionalDisconnect = false;
+
+  readonly notifications$: Observable<Notification> = this.notificationsSubject.asObservable();
+
+  connect(token: string): void {
+    this.intentionalDisconnect = false;
+    this.currentToken = token;
+    this.retryCount = 0;
+    this.openSocket(token);
+  }
+
+  disconnect(): void {
+    this.intentionalDisconnect = true;
+    this.currentToken = null;
+    this.clearTimers();
+    if (this.socket) {
+      this.socket.close();
+      this.socket = null;
+    }
+  }
+
+  private openSocket(token: string): void {
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const host = window.location.host;
+    const url = `${protocol}://${host}/api/v1/ws/notifications?token=${token}`;
+
+    this.socket = new WebSocket(url);
+
+    this.socket.onopen = () => {
+      this.retryCount = 0;
+      this.startPing();
+    };
+
+    this.socket.onmessage = (event: MessageEvent) => {
+      if (event.data === 'pong') return;
+      try {
+        const notification: Notification = JSON.parse(event.data as string);
+        this.notificationsSubject.next(notification);
+      } catch {
+        // ignore non-JSON frames
+      }
+    };
+
+    this.socket.onclose = () => {
+      this.clearPing();
+      if (!this.intentionalDisconnect && this.currentToken) {
+        this.scheduleReconnect();
+      }
+    };
+
+    this.socket.onerror = () => {
+      this.socket?.close();
+    };
+  }
+
+  private startPing(): void {
+    this.clearPing();
+    this.pingTimer = setInterval(() => {
+      if (this.socket?.readyState === WebSocket.OPEN) {
+        this.socket.send('ping');
+      }
+    }, 30_000);
+  }
+
+  private scheduleReconnect(): void {
+    const delay = Math.min(Math.pow(2, this.retryCount) * 1_000, this.maxRetryDelay);
+    this.retryCount++;
+    this.reconnectTimer = setTimeout(() => {
+      if (this.currentToken && !this.intentionalDisconnect) {
+        this.openSocket(this.currentToken);
+      }
+    }, delay);
+  }
+
+  private clearTimers(): void {
+    this.clearPing();
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  private clearPing(): void {
+    if (this.pingTimer !== null) {
+      clearInterval(this.pingTimer);
+      this.pingTimer = null;
+    }
+  }
+}

--- a/frontend/src/app/features/admin/pages/attendance/attendance.component.ts
+++ b/frontend/src/app/features/admin/pages/attendance/attendance.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, inject, signal, computed } from '@angular/core';
 import { CommonModule, DatePipe, DecimalPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
+import { NotificationBellComponent } from '../../../../core/components/notification-bell/notification-bell.component';
 import { forkJoin } from 'rxjs';
 import { AttendanceService } from '../../../../core/services/attendance.service';
 import { EmployeeService } from '../../../../core/services/employee.service';
@@ -31,7 +32,7 @@ interface AttendanceSummary {
 @Component({
   selector: 'app-attendance',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterLink, DatePipe, DecimalPipe],
+  imports: [CommonModule, FormsModule, RouterLink, DatePipe, DecimalPipe, NotificationBellComponent],
   template: `
     <div class="attendance-page">
       <header class="header">
@@ -42,10 +43,13 @@ interface AttendanceSummary {
           <h1>Control de Asistencia</h1>
           <p class="subtitle">Monitoreo y reportes de asistencia del personal</p>
         </div>
-        <button class="export-btn" (click)="exportToCSV()" [disabled]="loading() || filteredAttendance().length === 0">
+        <div class="header-actions" style="display:flex;align-items:center;gap:0.75rem;">
+          <app-notification-bell />
+          <button class="export-btn" (click)="exportToCSV()" [disabled]="loading() || filteredAttendance().length === 0">
           <span class="export-icon">&#8681;</span>
           Exportar CSV
         </button>
+        </div>
       </header>
 
       <!-- Summary Cards -->

--- a/frontend/src/app/features/admin/pages/dashboard/dashboard.component.ts
+++ b/frontend/src/app/features/admin/pages/dashboard/dashboard.component.ts
@@ -6,11 +6,12 @@ import { AttendanceService } from '../../../../core/services/attendance.service'
 import { EmployeeService } from '../../../../core/services/employee.service';
 import { AttendanceRecord } from '../../../../core/models/attendance.model';
 import { Employee } from '../../../../core/models/employee.model';
+import { NotificationBellComponent } from '../../../../core/components/notification-bell/notification-bell.component';
 
 @Component({
   selector: 'app-dashboard',
   standalone: true,
-  imports: [CommonModule, RouterLink],
+  imports: [CommonModule, RouterLink, NotificationBellComponent],
   template: `
     <div class="dashboard">
       <!-- Header -->
@@ -20,6 +21,7 @@ import { Employee } from '../../../../core/models/employee.model';
           <p>Bienvenido, {{ authService.user()?.full_name || authService.user()?.email }}</p>
         </div>
         <div class="header-right">
+          <app-notification-bell />
           <a routerLink="/kiosk" class="btn btn-secondary">Ir al Kiosko</a>
           <button class="btn btn-outline" (click)="logout()">Cerrar Sesión</button>
         </div>
@@ -81,6 +83,11 @@ import { Employee } from '../../../../core/models/employee.model';
           <div class="nav-icon">🎓</div>
           <h3>Puestos</h3>
           <p>Gestionar cargos y puestos</p>
+        </a>
+        <a routerLink="/admin/permission-requests" class="nav-card">
+          <div class="nav-icon">📝</div>
+          <h3>Solicitudes</h3>
+          <p>Revisar y aprobar permisos</p>
         </a>
         <a routerLink="/admin/settings" class="nav-card">
           <div class="nav-icon">⚙️</div>
@@ -152,6 +159,7 @@ import { Employee } from '../../../../core/models/employee.model';
     .header-right {
       display: flex;
       gap: 0.75rem;
+      align-items: center;
     }
 
     .btn {

--- a/frontend/src/app/features/admin/pages/departments/departments.component.ts
+++ b/frontend/src/app/features/admin/pages/departments/departments.component.ts
@@ -4,11 +4,12 @@ import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { DepartmentService } from '../../../../core/services/department.service';
 import { Department } from '../../../../core/models/department.model';
+import { NotificationBellComponent } from '../../../../core/components/notification-bell/notification-bell.component';
 
 @Component({
   selector: 'app-departments',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterLink],
+  imports: [CommonModule, FormsModule, RouterLink, NotificationBellComponent],
   template: `
     <div class="page">
       <header class="header">
@@ -16,7 +17,10 @@ import { Department } from '../../../../core/models/department.model';
           <a routerLink="/admin/dashboard" class="back-link">← Dashboard</a>
           <h1>Departamentos / Facultades</h1>
         </div>
-        <button class="btn btn-primary" (click)="openCreateModal()">+ Nuevo Departamento</button>
+        <div class="header-right">
+          <app-notification-bell />
+          <button class="btn btn-primary" (click)="openCreateModal()">+ Nuevo Departamento</button>
+        </div>
       </header>
 
       <!-- Table -->
@@ -99,6 +103,7 @@ import { Department } from '../../../../core/models/department.model';
   styles: [`
     .page { min-height: 100dvh; background: #f3f4f6; padding: 2rem; }
     .header { display: flex; justify-content: space-between; align-items: flex-end; margin-bottom: 2rem; }
+    .header-right { display: flex; align-items: center; gap: 0.75rem; }
     .back-link { color: #6b7280; text-decoration: none; font-size: 0.875rem; display: block; margin-bottom: 0.25rem; }
     h1 { font-size: 1.8rem; color: #1f2937; margin: 0; }
     .table-container { background: white; border-radius: 1rem; box-shadow: 0 1px 3px rgba(0,0,0,0.1); overflow: hidden; }

--- a/frontend/src/app/features/admin/pages/employees/employees.component.ts
+++ b/frontend/src/app/features/admin/pages/employees/employees.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, ViewChild, ElementRef, inject, signal } from '@angul
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
+import { NotificationBellComponent } from '../../../../core/components/notification-bell/notification-bell.component';
 import { forkJoin } from 'rxjs';
 import { EmployeeService } from '../../../../core/services/employee.service';
 import { PositionService } from '../../../../core/services/position.service';
@@ -16,7 +17,7 @@ import { Location } from '../../../../core/models/location.model';
 @Component({
   selector: 'app-employees',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterLink],
+  imports: [CommonModule, FormsModule, RouterLink, NotificationBellComponent],
   template: `
     <div class="employees-page">
       <header class="header">
@@ -24,9 +25,12 @@ import { Location } from '../../../../core/models/location.model';
           <a routerLink="/admin/dashboard" class="back-link">← Dashboard</a>
           <h1>Empleados</h1>
         </div>
-        <button class="btn btn-primary" (click)="openCreateModal()">
-          + Nuevo Empleado
-        </button>
+        <div class="header-right">
+          <app-notification-bell />
+          <button class="btn btn-primary" (click)="openCreateModal()">
+            + Nuevo Empleado
+          </button>
+        </div>
       </header>
 
       <!-- Desktop table -->

--- a/frontend/src/app/features/admin/pages/locations/locations.component.ts
+++ b/frontend/src/app/features/admin/pages/locations/locations.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, AfterViewInit, inject, signal, ElementRef, ViewChild
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
+import { NotificationBellComponent } from '../../../../core/components/notification-bell/notification-bell.component';
 import * as L from 'leaflet';
 import { LocationService } from '../../../../core/services/location.service';
 import { Location, LocationCreate } from '../../../../core/models/location.model';
@@ -9,7 +10,7 @@ import { Location, LocationCreate } from '../../../../core/models/location.model
 @Component({
   selector: 'app-locations',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterLink],
+  imports: [CommonModule, FormsModule, RouterLink, NotificationBellComponent],
   template: `
     <div class="locations-page">
       <header class="header">
@@ -17,9 +18,12 @@ import { Location, LocationCreate } from '../../../../core/models/location.model
           <a routerLink="/admin/dashboard" class="back-link">← Dashboard</a>
           <h1>Sedes / Ubicaciones</h1>
         </div>
-        <button class="btn btn-primary" (click)="openCreateModal()">
-          + Nueva Sede
-        </button>
+        <div class="header-right" style="display:flex;align-items:center;gap:0.75rem;">
+          <app-notification-bell />
+          <button class="btn btn-primary" (click)="openCreateModal()">
+            + Nueva Sede
+          </button>
+        </div>
       </header>
 
       <div class="content">

--- a/frontend/src/app/features/admin/pages/permission-requests/permission-requests.component.ts
+++ b/frontend/src/app/features/admin/pages/permission-requests/permission-requests.component.ts
@@ -1,0 +1,682 @@
+import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { PermissionRequestService } from '../../../../core/services/permission-request.service';
+import { EmployeeService } from '../../../../core/services/employee.service';
+import { AuthService } from '../../../../core/services/auth.service';
+import {
+  PermissionRequest,
+  PermissionRequestStatus,
+  STATUS_LABELS,
+  STATUS_COLORS,
+} from '../../../../core/models/permission-request.model';
+import { Employee } from '../../../../core/models/employee.model';
+import { EXCEPTION_TYPE_LABELS, ExceptionType } from '../../../../core/models/schedule.model';
+import { NotificationBellComponent } from '../../../../core/components/notification-bell/notification-bell.component';
+
+type FilterTab = 'all' | PermissionRequestStatus;
+
+@Component({
+  selector: 'app-permission-requests',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink, NotificationBellComponent],
+  template: `
+    <div class="page">
+      <header class="header">
+        <div>
+          <a routerLink="/admin/dashboard" class="back-link">← Dashboard</a>
+          <h1>Solicitudes de Permiso</h1>
+        </div>
+        <div class="header-right">
+          <app-notification-bell />
+        </div>
+      </header>
+
+      <!-- Filter tabs -->
+      <div class="tabs">
+        @for (tab of tabs; track tab.value) {
+          <button
+            class="tab-btn"
+            [class.active]="activeTab() === tab.value"
+            (click)="setTab(tab.value)"
+          >
+            {{ tab.label }}
+            @if (countByStatus(tab.value) > 0) {
+              <span class="tab-count">{{ countByStatus(tab.value) }}</span>
+            }
+          </button>
+        }
+      </div>
+
+      <!-- Loading -->
+      @if (loading()) {
+        <div class="loading">Cargando solicitudes...</div>
+      }
+
+      <!-- Empty state -->
+      @if (!loading() && filteredRequests().length === 0) {
+        <div class="empty-card">
+          <div class="empty-icon">📋</div>
+          <p>No hay solicitudes en esta categoría.</p>
+        </div>
+      }
+
+      <!-- Cards -->
+      <div class="cards-grid">
+        @for (req of filteredRequests(); track req.id) {
+          <div class="request-card">
+            <div class="card-header">
+              <div class="card-meta">
+                <span class="employee-name">{{ getEmployeeName(req.employee_id) }}</span>
+                <span
+                  class="status-badge"
+                  [style.background]="getStatusBg(req.status)"
+                  [style.color]="STATUS_COLORS[req.status]"
+                >
+                  {{ STATUS_LABELS[req.status] }}
+                </span>
+              </div>
+              <span class="exception-type">{{ getExceptionLabel(req.exception_type) }}</span>
+            </div>
+
+            <div class="card-dates">
+              📅 {{ req.start_date | date: 'dd/MM/yyyy' }} — {{ req.end_date | date: 'dd/MM/yyyy' }}
+            </div>
+
+            @if (req.description) {
+              <div class="card-description">{{ req.description }}</div>
+            }
+
+            @if (req.rejection_reason) {
+              <div class="rejection-reason">
+                <strong>Rechazo:</strong> {{ req.rejection_reason }}
+              </div>
+            }
+
+            <div class="card-footer">
+              <span class="card-date">{{ req.created_at | date: 'dd/MM/yyyy HH:mm' }}</span>
+              <div class="card-actions">
+                @if (canApprove(req)) {
+                  <button class="btn btn-approve" (click)="openApproveModal(req)">Aprobar</button>
+                }
+                @if (canReject(req)) {
+                  <button class="btn btn-reject" (click)="openRejectModal(req)">Rechazar</button>
+                }
+              </div>
+            </div>
+          </div>
+        }
+      </div>
+
+      <!-- Approve Modal -->
+      @if (approveTarget()) {
+        <div class="modal-overlay" (click)="closeModals()">
+          <div class="modal" (click)="$event.stopPropagation()">
+            <div class="modal-header">
+              <h2>Aprobar Solicitud</h2>
+              <button class="close-btn" (click)="closeModals()">✕</button>
+            </div>
+            <div class="modal-body">
+              <p class="modal-desc">
+                Vas a aprobar la solicitud de
+                <strong>{{ getEmployeeName(approveTarget()!.employee_id) }}</strong>
+                para <strong>{{ getExceptionLabel(approveTarget()!.exception_type) }}</strong>.
+              </p>
+              <div class="form-group">
+                <label>Notas (opcional)</label>
+                <textarea
+                  [(ngModel)]="approveNotes"
+                  rows="3"
+                  placeholder="Notas adicionales..."
+                ></textarea>
+              </div>
+              @if (actionError()) {
+                <div class="error-message">{{ actionError() }}</div>
+              }
+            </div>
+            <div class="modal-actions">
+              <button class="btn btn-outline" (click)="closeModals()">Cancelar</button>
+              <button class="btn btn-approve" [disabled]="actionLoading()" (click)="confirmApprove()">
+                {{ actionLoading() ? 'Procesando...' : 'Confirmar Aprobación' }}
+              </button>
+            </div>
+          </div>
+        </div>
+      }
+
+      <!-- Reject Modal -->
+      @if (rejectTarget()) {
+        <div class="modal-overlay" (click)="closeModals()">
+          <div class="modal" (click)="$event.stopPropagation()">
+            <div class="modal-header">
+              <h2>Rechazar Solicitud</h2>
+              <button class="close-btn" (click)="closeModals()">✕</button>
+            </div>
+            <div class="modal-body">
+              <p class="modal-desc">
+                Vas a rechazar la solicitud de
+                <strong>{{ getEmployeeName(rejectTarget()!.employee_id) }}</strong>.
+              </p>
+              <div class="form-group">
+                <label>Motivo de Rechazo <span class="required">*</span></label>
+                <textarea
+                  [(ngModel)]="rejectReason"
+                  rows="3"
+                  placeholder="Especificá el motivo del rechazo..."
+                  required
+                ></textarea>
+              </div>
+              @if (actionError()) {
+                <div class="error-message">{{ actionError() }}</div>
+              }
+            </div>
+            <div class="modal-actions">
+              <button class="btn btn-outline" (click)="closeModals()">Cancelar</button>
+              <button class="btn btn-reject" [disabled]="actionLoading()" (click)="confirmReject()">
+                {{ actionLoading() ? 'Procesando...' : 'Confirmar Rechazo' }}
+              </button>
+            </div>
+          </div>
+        </div>
+      }
+    </div>
+  `,
+  styles: [`
+    .page {
+      min-height: 100dvh;
+      background: #f3f4f6;
+      padding: 2rem;
+    }
+
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 2rem;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+
+    .header-right {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .back-link {
+      display: inline-block;
+      color: #6b7280;
+      text-decoration: none;
+      font-size: 0.875rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .back-link:hover { color: #3b82f6; }
+
+    h1 {
+      font-size: 1.8rem;
+      color: #1f2937;
+      margin: 0;
+    }
+
+    .tabs {
+      display: flex;
+      gap: 0.5rem;
+      margin-bottom: 1.5rem;
+      flex-wrap: wrap;
+    }
+
+    .tab-btn {
+      padding: 0.5rem 1rem;
+      border-radius: 0.5rem;
+      border: 2px solid #e5e7eb;
+      background: white;
+      color: #374151;
+      cursor: pointer;
+      font-size: 0.875rem;
+      font-weight: 500;
+      transition: all 0.2s;
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+    }
+
+    .tab-btn:hover { border-color: #3b82f6; color: #3b82f6; }
+
+    .tab-btn.active {
+      background: #3b82f6;
+      border-color: #3b82f6;
+      color: white;
+    }
+
+    .tab-count {
+      background: rgba(255,255,255,0.3);
+      padding: 0 6px;
+      border-radius: 9999px;
+      font-size: 0.7rem;
+      font-weight: 700;
+    }
+
+    .tab-btn:not(.active) .tab-count {
+      background: #e5e7eb;
+      color: #374151;
+    }
+
+    .loading {
+      text-align: center;
+      color: #6b7280;
+      padding: 3rem;
+    }
+
+    .empty-card {
+      background: white;
+      border-radius: 1rem;
+      padding: 3rem;
+      text-align: center;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    }
+
+    .empty-icon { font-size: 3rem; margin-bottom: 1rem; }
+    .empty-card p { color: #6b7280; }
+
+    .cards-grid {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .request-card {
+      background: white;
+      border-radius: 1rem;
+      padding: 1.25rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    }
+
+    .card-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .card-meta {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .employee-name {
+      font-weight: 600;
+      color: #1f2937;
+    }
+
+    .exception-type {
+      font-size: 0.875rem;
+      color: #6b7280;
+    }
+
+    .status-badge {
+      padding: 0.25rem 0.75rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+
+    .card-dates {
+      color: #6b7280;
+      font-size: 0.875rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .card-description {
+      color: #4b5563;
+      font-size: 0.875rem;
+      line-height: 1.5;
+      margin-bottom: 0.75rem;
+    }
+
+    .rejection-reason {
+      background: #fef2f2;
+      color: #991b1b;
+      font-size: 0.8rem;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.5rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .card-footer {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      border-top: 1px solid #f3f4f6;
+      padding-top: 0.75rem;
+    }
+
+    .card-date {
+      color: #9ca3af;
+      font-size: 0.75rem;
+    }
+
+    .card-actions {
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    .btn {
+      padding: 0.5rem 1rem;
+      border-radius: 0.5rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.2s;
+      border: none;
+      font-size: 0.875rem;
+    }
+
+    .btn-approve {
+      background: #10b981;
+      color: white;
+    }
+
+    .btn-approve:hover:not(:disabled) { background: #059669; }
+    .btn-approve:disabled { opacity: 0.6; cursor: not-allowed; }
+
+    .btn-reject {
+      background: #ef4444;
+      color: white;
+    }
+
+    .btn-reject:hover:not(:disabled) { background: #dc2626; }
+    .btn-reject:disabled { opacity: 0.6; cursor: not-allowed; }
+
+    .btn-outline {
+      background: transparent;
+      border: 2px solid #d1d5db;
+      color: #374151;
+    }
+
+    .btn-outline:hover { border-color: #9ca3af; }
+
+    /* Modal */
+    .modal-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.5);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 200;
+      padding: 1rem;
+    }
+
+    .modal {
+      background: white;
+      border-radius: 1rem;
+      width: 100%;
+      max-width: 460px;
+      box-shadow: 0 20px 60px rgba(0,0,0,0.2);
+    }
+
+    .modal-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1.5rem 1.5rem 0;
+    }
+
+    .modal-header h2 {
+      font-size: 1.25rem;
+      color: #1f2937;
+    }
+
+    .close-btn {
+      background: none;
+      border: none;
+      font-size: 1.1rem;
+      cursor: pointer;
+      color: #9ca3af;
+      padding: 0.25rem;
+    }
+
+    .close-btn:hover { color: #374151; }
+
+    .modal-body {
+      padding: 1.25rem 1.5rem;
+    }
+
+    .modal-desc {
+      color: #4b5563;
+      font-size: 0.9rem;
+      margin-bottom: 1rem;
+      line-height: 1.5;
+    }
+
+    .form-group {
+      margin-bottom: 1rem;
+    }
+
+    label {
+      display: block;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: #374151;
+      margin-bottom: 0.375rem;
+    }
+
+    .required { color: #ef4444; }
+
+    textarea {
+      width: 100%;
+      padding: 0.625rem 0.75rem;
+      border: 2px solid #e5e7eb;
+      border-radius: 0.5rem;
+      font-size: 0.9rem;
+      color: #1f2937;
+      box-sizing: border-box;
+      transition: border-color 0.2s;
+      resize: vertical;
+    }
+
+    textarea:focus {
+      outline: none;
+      border-color: #3b82f6;
+    }
+
+    .error-message {
+      background: #fef2f2;
+      color: #dc2626;
+      padding: 0.75rem;
+      border-radius: 0.5rem;
+      font-size: 0.875rem;
+    }
+
+    .modal-actions {
+      display: flex;
+      gap: 0.75rem;
+      justify-content: flex-end;
+      padding: 0 1.5rem 1.5rem;
+    }
+
+    @media (max-width: 768px) {
+      .page { padding: 1rem; }
+      h1 { font-size: 1.5rem; }
+    }
+
+    @media (max-width: 480px) {
+      .page { padding: 0.75rem; }
+      h1 { font-size: 1.25rem; }
+      .tabs { gap: 0.375rem; }
+      .tab-btn { font-size: 0.8rem; padding: 0.4rem 0.75rem; }
+      .modal-actions { flex-direction: column-reverse; }
+      .modal-actions .btn { width: 100%; text-align: center; }
+    }
+  `],
+})
+export class AdminPermissionRequestsComponent implements OnInit {
+  readonly STATUS_LABELS = STATUS_LABELS;
+  readonly STATUS_COLORS = STATUS_COLORS;
+
+  private readonly requestService = inject(PermissionRequestService);
+  private readonly employeeService = inject(EmployeeService);
+  readonly authService = inject(AuthService);
+
+  readonly requests = signal<PermissionRequest[]>([]);
+  readonly employees = signal<Employee[]>([]);
+  readonly loading = signal(false);
+  readonly activeTab = signal<FilterTab>('all');
+
+  readonly approveTarget = signal<PermissionRequest | null>(null);
+  readonly rejectTarget = signal<PermissionRequest | null>(null);
+  readonly actionLoading = signal(false);
+  readonly actionError = signal<string | null>(null);
+
+  approveNotes = '';
+  rejectReason = '';
+
+  readonly tabs: { value: FilterTab; label: string }[] = [
+    { value: 'all', label: 'Todos' },
+    { value: 'pending', label: 'Pendientes' },
+    { value: 'coordinator_approved', label: 'Aprobados Coordinador' },
+    { value: 'approved', label: 'Aprobados' },
+    { value: 'rejected', label: 'Rechazados' },
+  ];
+
+  readonly filteredRequests = computed(() => {
+    const tab = this.activeTab();
+    if (tab === 'all') return this.requests();
+    return this.requests().filter((r) => r.status === tab);
+  });
+
+  readonly employeeMap = computed(() => {
+    const map = new Map<string, string>();
+    this.employees().forEach((e) => map.set(e.id, `${e.first_name} ${e.last_name}`));
+    return map;
+  });
+
+  ngOnInit(): void {
+    this.loadAll();
+  }
+
+  loadAll(): void {
+    this.loading.set(true);
+    this.requestService.getAll().subscribe({
+      next: (list) => {
+        this.requests.set(list);
+        this.loading.set(false);
+      },
+      error: () => this.loading.set(false),
+    });
+    this.employeeService.getAll({ active_only: true }).subscribe({
+      next: (list) => this.employees.set(list),
+      error: () => {},
+    });
+  }
+
+  setTab(tab: FilterTab): void {
+    this.activeTab.set(tab);
+  }
+
+  countByStatus(tab: FilterTab): number {
+    if (tab === 'all') return this.requests().length;
+    return this.requests().filter((r) => r.status === tab).length;
+  }
+
+  canApprove(req: PermissionRequest): boolean {
+    const role = this.authService.user()?.role;
+    if (!role) return false;
+    // pending -> coordinator or admin can approve
+    if (req.status === 'pending' && (role === 'admin' || role === 'coordinador')) return true;
+    // coordinator_approved -> director or admin can do final approval
+    if (req.status === 'coordinator_approved' && (role === 'admin' || role === 'director')) return true;
+    return false;
+  }
+
+  canReject(req: PermissionRequest): boolean {
+    return this.canApprove(req);
+  }
+
+  openApproveModal(req: PermissionRequest): void {
+    this.approveNotes = '';
+    this.actionError.set(null);
+    this.approveTarget.set(req);
+  }
+
+  openRejectModal(req: PermissionRequest): void {
+    this.rejectReason = '';
+    this.actionError.set(null);
+    this.rejectTarget.set(req);
+  }
+
+  closeModals(): void {
+    this.approveTarget.set(null);
+    this.rejectTarget.set(null);
+    this.actionError.set(null);
+  }
+
+  confirmApprove(): void {
+    const target = this.approveTarget();
+    if (!target) return;
+
+    this.actionLoading.set(true);
+    this.actionError.set(null);
+
+    this.requestService.approve(target.id, this.approveNotes || undefined).subscribe({
+      next: () => {
+        this.actionLoading.set(false);
+        this.closeModals();
+        this.loadAll();
+      },
+      error: (err) => {
+        this.actionLoading.set(false);
+        this.actionError.set(err.error?.detail || 'Error al aprobar la solicitud.');
+      },
+    });
+  }
+
+  confirmReject(): void {
+    const target = this.rejectTarget();
+    if (!target) return;
+
+    if (!this.rejectReason.trim()) {
+      this.actionError.set('El motivo de rechazo es requerido.');
+      return;
+    }
+
+    this.actionLoading.set(true);
+    this.actionError.set(null);
+
+    this.requestService.reject(target.id, this.rejectReason).subscribe({
+      next: () => {
+        this.actionLoading.set(false);
+        this.closeModals();
+        this.loadAll();
+      },
+      error: (err) => {
+        this.actionLoading.set(false);
+        this.actionError.set(err.error?.detail || 'Error al rechazar la solicitud.');
+      },
+    });
+  }
+
+  getEmployeeName(id: string): string {
+    return this.employeeMap().get(id) ?? 'Empleado';
+  }
+
+  getExceptionLabel(type: string): string {
+    return EXCEPTION_TYPE_LABELS[type as ExceptionType] ?? type;
+  }
+
+  getStatusBg(status: string): string {
+    const map: Record<string, string> = {
+      pending: '#fffbeb',
+      coordinator_approved: '#eff6ff',
+      approved: '#f0fdf4',
+      rejected: '#fef2f2',
+    };
+    return map[status] ?? '#f3f4f6';
+  }
+}

--- a/frontend/src/app/features/admin/pages/positions/positions.component.ts
+++ b/frontend/src/app/features/admin/pages/positions/positions.component.ts
@@ -4,11 +4,12 @@ import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
 import { PositionService } from '../../../../core/services/position.service';
 import { Position } from '../../../../core/models/position.model';
+import { NotificationBellComponent } from '../../../../core/components/notification-bell/notification-bell.component';
 
 @Component({
   selector: 'app-positions',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterLink],
+  imports: [CommonModule, FormsModule, RouterLink, NotificationBellComponent],
   template: `
     <div class="page">
       <header class="header">
@@ -16,7 +17,10 @@ import { Position } from '../../../../core/models/position.model';
           <a routerLink="/admin/dashboard" class="back-link">← Dashboard</a>
           <h1>Puestos / Cargos</h1>
         </div>
-        <button class="btn btn-primary" (click)="openCreateModal()">+ Nuevo Puesto</button>
+        <div class="header-right">
+          <app-notification-bell />
+          <button class="btn btn-primary" (click)="openCreateModal()">+ Nuevo Puesto</button>
+        </div>
       </header>
 
       <!-- Table -->
@@ -99,6 +103,7 @@ import { Position } from '../../../../core/models/position.model';
   styles: [`
     .page { min-height: 100dvh; background: #f3f4f6; padding: 2rem; }
     .header { display: flex; justify-content: space-between; align-items: flex-end; margin-bottom: 2rem; }
+    .header-right { display: flex; align-items: center; gap: 0.75rem; }
     .back-link { color: #6b7280; text-decoration: none; font-size: 0.875rem; display: block; margin-bottom: 0.25rem; }
     h1 { font-size: 1.8rem; color: #1f2937; margin: 0; }
     .table-container { background: white; border-radius: 1rem; box-shadow: 0 1px 3px rgba(0,0,0,0.1); overflow: hidden; }

--- a/frontend/src/app/features/admin/pages/schedules/schedules.component.ts
+++ b/frontend/src/app/features/admin/pages/schedules/schedules.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
+import { NotificationBellComponent } from '../../../../core/components/notification-bell/notification-bell.component';
 import { forkJoin, catchError, of } from 'rxjs';
 import { ScheduleService } from '../../../../core/services/schedule.service';
 import { EmployeeService } from '../../../../core/services/employee.service';
@@ -44,6 +45,7 @@ interface WeekDay {
           <p class="subtitle">Gestion de horarios y asignaciones del personal</p>
         </div>
         <div class="header-actions">
+          <app-notification-bell />
           <button class="btn btn-outline" (click)="exportCalendar()">
             <span class="btn-icon">&#8681;</span> Exportar
           </button>

--- a/frontend/src/app/features/admin/pages/settings/settings.component.ts
+++ b/frontend/src/app/features/admin/pages/settings/settings.component.ts
@@ -2,13 +2,14 @@ import { Component, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { RouterLink } from '@angular/router';
+import { NotificationBellComponent } from '../../../../core/components/notification-bell/notification-bell.component';
 import { SettingsService } from '../../../../core/services/settings.service';
 import { Settings, SettingsUpdate } from '../../../../core/models/settings.model';
 
 @Component({
   selector: 'app-settings',
   standalone: true,
-  imports: [CommonModule, FormsModule, RouterLink],
+  imports: [CommonModule, FormsModule, RouterLink, NotificationBellComponent],
   template: `
     <div class="settings-page">
       <header class="header">
@@ -16,6 +17,7 @@ import { Settings, SettingsUpdate } from '../../../../core/models/settings.model
           <a routerLink="/admin/dashboard" class="back-link">← Dashboard</a>
           <h1>Configuración</h1>
         </div>
+        <app-notification-bell />
       </header>
 
       @if (loading()) {

--- a/frontend/src/app/features/requests/pages/my-requests/my-requests.component.ts
+++ b/frontend/src/app/features/requests/pages/my-requests/my-requests.component.ts
@@ -1,0 +1,588 @@
+import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { PermissionRequestService } from '../../../../core/services/permission-request.service';
+import { EmployeeService } from '../../../../core/services/employee.service';
+import { AuthService } from '../../../../core/services/auth.service';
+import {
+  PermissionRequest,
+  PermissionRequestCreate,
+  STATUS_LABELS,
+  STATUS_COLORS,
+} from '../../../../core/models/permission-request.model';
+import { Employee } from '../../../../core/models/employee.model';
+import { EXCEPTION_TYPE_LABELS, ExceptionType } from '../../../../core/models/schedule.model';
+
+@Component({
+  selector: 'app-my-requests',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink],
+  template: `
+    <div class="page">
+      <header class="header">
+        <div>
+          <a routerLink="/admin/dashboard" class="back-link">← Dashboard</a>
+          <h1>Mis Solicitudes de Permiso</h1>
+        </div>
+        <button class="btn btn-primary" (click)="openModal()">
+          + Nueva Solicitud
+        </button>
+      </header>
+
+      <!-- Loading -->
+      @if (loading()) {
+        <div class="loading">Cargando solicitudes...</div>
+      }
+
+      <!-- Empty state -->
+      @if (!loading() && requests().length === 0) {
+        <div class="empty-card">
+          <div class="empty-icon">📋</div>
+          <p>No tenés solicitudes de permiso aún.</p>
+          <button class="btn btn-primary" (click)="openModal()">Crear primera solicitud</button>
+        </div>
+      }
+
+      <!-- Request cards -->
+      <div class="cards-grid">
+        @for (req of requests(); track req.id) {
+          <div class="request-card">
+            <div class="card-top">
+              <div class="card-meta">
+                <span class="exception-type">{{ getExceptionLabel(req.exception_type) }}</span>
+                <span
+                  class="status-badge"
+                  [style.background]="getStatusBg(req.status)"
+                  [style.color]="getStatusColor(req.status)"
+                >
+                  {{ getStatusLabel(req.status) }}
+                </span>
+              </div>
+              <div class="card-dates">
+                {{ req.start_date | date: 'dd/MM/yyyy' }} — {{ req.end_date | date: 'dd/MM/yyyy' }}
+              </div>
+            </div>
+            @if (req.description) {
+              <div class="card-description">{{ req.description }}</div>
+            }
+            @if (req.rejection_reason) {
+              <div class="rejection-reason">
+                <strong>Motivo de rechazo:</strong> {{ req.rejection_reason }}
+              </div>
+            }
+            <div class="card-footer">
+              <span class="card-date">Enviado: {{ req.created_at | date: 'dd/MM/yyyy HH:mm' }}</span>
+            </div>
+          </div>
+        }
+      </div>
+
+      <!-- Modal -->
+      @if (showModal()) {
+        <div class="modal-overlay" (click)="closeModal()">
+          <div class="modal" (click)="$event.stopPropagation()">
+            <div class="modal-header">
+              <h2>Nueva Solicitud de Permiso</h2>
+              <button class="close-btn" (click)="closeModal()">✕</button>
+            </div>
+            <form (ngSubmit)="submitRequest()">
+              <div class="form-group">
+                <label>Empleado</label>
+                <select [(ngModel)]="form.employee_id" name="employee_id" required>
+                  <option value="">Seleccioná un empleado</option>
+                  @for (emp of employees(); track emp.id) {
+                    <option [value]="emp.id">{{ emp.first_name }} {{ emp.last_name }}</option>
+                  }
+                </select>
+              </div>
+
+              <div class="form-group">
+                <label>Tipo de Excepción</label>
+                <select [(ngModel)]="form.exception_type" name="exception_type" required>
+                  <option value="">Seleccioná un tipo</option>
+                  @for (entry of exceptionTypes; track entry.value) {
+                    <option [value]="entry.value">{{ entry.label }}</option>
+                  }
+                </select>
+              </div>
+
+              <div class="form-row">
+                <div class="form-group">
+                  <label>Fecha Inicio</label>
+                  <input
+                    type="date"
+                    [(ngModel)]="form.start_date"
+                    name="start_date"
+                    [min]="minDate()"
+                    required
+                    (change)="validateDates()"
+                  />
+                  @if (dateError()) {
+                    <span class="field-error">{{ dateError() }}</span>
+                  }
+                </div>
+                <div class="form-group">
+                  <label>Fecha Fin</label>
+                  <input
+                    type="date"
+                    [(ngModel)]="form.end_date"
+                    name="end_date"
+                    [min]="form.start_date || minDate()"
+                    required
+                  />
+                </div>
+              </div>
+
+              <div class="form-group">
+                <label>Descripción / Motivo</label>
+                <textarea
+                  [(ngModel)]="form.description"
+                  name="description"
+                  rows="3"
+                  placeholder="Describí el motivo de tu solicitud..."
+                ></textarea>
+              </div>
+
+              @if (submitError()) {
+                <div class="error-message">{{ submitError() }}</div>
+              }
+
+              <div class="modal-actions">
+                <button type="button" class="btn btn-outline" (click)="closeModal()">
+                  Cancelar
+                </button>
+                <button type="submit" class="btn btn-primary" [disabled]="submitting()">
+                  {{ submitting() ? 'Enviando...' : 'Enviar Solicitud' }}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      }
+    </div>
+  `,
+  styles: [`
+    .page {
+      min-height: 100dvh;
+      background: #f3f4f6;
+      padding: 2rem;
+    }
+
+    .header {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 2rem;
+      flex-wrap: wrap;
+      gap: 1rem;
+    }
+
+    .back-link {
+      display: inline-block;
+      color: #6b7280;
+      text-decoration: none;
+      font-size: 0.875rem;
+      margin-bottom: 0.5rem;
+    }
+
+    .back-link:hover { color: #3b82f6; }
+
+    h1 {
+      font-size: 1.8rem;
+      color: #1f2937;
+      margin: 0;
+    }
+
+    .loading {
+      text-align: center;
+      color: #6b7280;
+      padding: 3rem;
+    }
+
+    .empty-card {
+      background: white;
+      border-radius: 1rem;
+      padding: 3rem;
+      text-align: center;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    }
+
+    .empty-icon { font-size: 3rem; margin-bottom: 1rem; }
+    .empty-card p { color: #6b7280; margin-bottom: 1.5rem; }
+
+    .cards-grid {
+      display: grid;
+      gap: 1rem;
+    }
+
+    .request-card {
+      background: white;
+      border-radius: 1rem;
+      padding: 1.25rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    }
+
+    .card-top {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .card-meta {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .exception-type {
+      font-weight: 600;
+      color: #1f2937;
+      font-size: 1rem;
+    }
+
+    .status-badge {
+      padding: 0.25rem 0.75rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 600;
+    }
+
+    .card-dates {
+      color: #6b7280;
+      font-size: 0.875rem;
+    }
+
+    .card-description {
+      color: #4b5563;
+      font-size: 0.875rem;
+      margin-bottom: 0.75rem;
+      line-height: 1.5;
+    }
+
+    .rejection-reason {
+      background: #fef2f2;
+      color: #991b1b;
+      font-size: 0.8rem;
+      padding: 0.5rem 0.75rem;
+      border-radius: 0.5rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .card-footer {
+      border-top: 1px solid #f3f4f6;
+      padding-top: 0.75rem;
+    }
+
+    .card-date {
+      color: #9ca3af;
+      font-size: 0.75rem;
+    }
+
+    /* Buttons */
+    .btn {
+      padding: 0.625rem 1.25rem;
+      border-radius: 0.5rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.2s;
+      border: none;
+      font-size: 0.9rem;
+    }
+
+    .btn-primary {
+      background: #3b82f6;
+      color: white;
+    }
+
+    .btn-primary:hover:not(:disabled) { background: #2563eb; }
+    .btn-primary:disabled { opacity: 0.6; cursor: not-allowed; }
+
+    .btn-outline {
+      background: transparent;
+      border: 2px solid #d1d5db;
+      color: #374151;
+    }
+
+    .btn-outline:hover { border-color: #9ca3af; }
+
+    /* Modal */
+    .modal-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.5);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 200;
+      padding: 1rem;
+    }
+
+    .modal {
+      background: white;
+      border-radius: 1rem;
+      width: 100%;
+      max-width: 520px;
+      max-height: 90vh;
+      overflow-y: auto;
+      box-shadow: 0 20px 60px rgba(0,0,0,0.2);
+    }
+
+    .modal-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 1.5rem 1.5rem 0;
+      margin-bottom: 1rem;
+    }
+
+    .modal-header h2 {
+      font-size: 1.25rem;
+      color: #1f2937;
+    }
+
+    .close-btn {
+      background: none;
+      border: none;
+      font-size: 1.1rem;
+      cursor: pointer;
+      color: #9ca3af;
+      padding: 0.25rem;
+    }
+
+    .close-btn:hover { color: #374151; }
+
+    form {
+      padding: 0 1.5rem 1.5rem;
+    }
+
+    .form-group {
+      margin-bottom: 1rem;
+    }
+
+    .form-row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+    }
+
+    label {
+      display: block;
+      font-size: 0.875rem;
+      font-weight: 500;
+      color: #374151;
+      margin-bottom: 0.375rem;
+    }
+
+    input, select, textarea {
+      width: 100%;
+      padding: 0.625rem 0.75rem;
+      border: 2px solid #e5e7eb;
+      border-radius: 0.5rem;
+      font-size: 0.9rem;
+      color: #1f2937;
+      box-sizing: border-box;
+      transition: border-color 0.2s;
+      background: white;
+    }
+
+    input:focus, select:focus, textarea:focus {
+      outline: none;
+      border-color: #3b82f6;
+    }
+
+    textarea { resize: vertical; }
+
+    .field-error {
+      color: #ef4444;
+      font-size: 0.75rem;
+      margin-top: 0.25rem;
+      display: block;
+    }
+
+    .error-message {
+      background: #fef2f2;
+      color: #dc2626;
+      padding: 0.75rem;
+      border-radius: 0.5rem;
+      font-size: 0.875rem;
+      margin-bottom: 1rem;
+    }
+
+    .modal-actions {
+      display: flex;
+      gap: 0.75rem;
+      justify-content: flex-end;
+      margin-top: 1.25rem;
+    }
+
+    @media (max-width: 768px) {
+      .page { padding: 1rem; }
+      h1 { font-size: 1.5rem; }
+    }
+
+    @media (max-width: 480px) {
+      .page { padding: 0.75rem; }
+      h1 { font-size: 1.25rem; }
+      .form-row { grid-template-columns: 1fr; }
+      .modal-actions { flex-direction: column-reverse; }
+      .modal-actions .btn { width: 100%; text-align: center; }
+    }
+  `],
+})
+export class MyRequestsComponent implements OnInit {
+  private readonly requestService = inject(PermissionRequestService);
+  private readonly employeeService = inject(EmployeeService);
+  readonly authService = inject(AuthService);
+
+  readonly requests = signal<PermissionRequest[]>([]);
+  readonly employees = signal<Employee[]>([]);
+  readonly loading = signal(false);
+  readonly showModal = signal(false);
+  readonly submitting = signal(false);
+  readonly submitError = signal<string | null>(null);
+  readonly dateError = signal<string | null>(null);
+
+  form: PermissionRequestCreate = {
+    employee_id: '',
+    exception_type: '',
+    start_date: '',
+    end_date: '',
+    description: '',
+  };
+
+  readonly exceptionTypes = Object.entries(EXCEPTION_TYPE_LABELS).map(([value, label]) => ({
+    value: value as ExceptionType,
+    label,
+  }));
+
+  readonly minDate = computed(() => {
+    const d = new Date();
+    d.setDate(d.getDate() + 7);
+    return d.toISOString().split('T')[0];
+  });
+
+  ngOnInit(): void {
+    this.loadRequests();
+    this.loadEmployees();
+  }
+
+  loadRequests(): void {
+    this.loading.set(true);
+    const user = this.authService.user();
+    this.requestService
+      .getAll(user ? { employee_id: undefined } : undefined)
+      .subscribe({
+        next: (list) => {
+          this.requests.set(list);
+          this.loading.set(false);
+        },
+        error: () => this.loading.set(false),
+      });
+  }
+
+  loadEmployees(): void {
+    this.employeeService.getAll({ active_only: true }).subscribe({
+      next: (list) => this.employees.set(list),
+      error: () => {},
+    });
+  }
+
+  openModal(): void {
+    this.resetForm();
+    this.showModal.set(true);
+  }
+
+  closeModal(): void {
+    this.showModal.set(false);
+    this.resetForm();
+  }
+
+  validateDates(): void {
+    if (!this.form.start_date) {
+      this.dateError.set(null);
+      return;
+    }
+    const start = new Date(this.form.start_date);
+    const minAllowed = new Date(this.minDate());
+    if (start < minAllowed) {
+      this.dateError.set('La fecha de inicio debe ser al menos 7 días desde hoy.');
+    } else {
+      this.dateError.set(null);
+    }
+  }
+
+  submitRequest(): void {
+    this.validateDates();
+    if (this.dateError()) return;
+
+    if (!this.form.employee_id || !this.form.exception_type || !this.form.start_date || !this.form.end_date) {
+      this.submitError.set('Completá todos los campos requeridos.');
+      return;
+    }
+
+    this.submitting.set(true);
+    this.submitError.set(null);
+
+    const payload: PermissionRequestCreate = {
+      employee_id: this.form.employee_id,
+      exception_type: this.form.exception_type,
+      start_date: this.form.start_date,
+      end_date: this.form.end_date,
+    };
+    if (this.form.description) {
+      payload.description = this.form.description;
+    }
+
+    this.requestService.create(payload).subscribe({
+      next: () => {
+        this.submitting.set(false);
+        this.closeModal();
+        this.loadRequests();
+      },
+      error: (err) => {
+        this.submitting.set(false);
+        this.submitError.set(err.error?.detail || 'Error al enviar la solicitud.');
+      },
+    });
+  }
+
+  getExceptionLabel(type: string): string {
+    return EXCEPTION_TYPE_LABELS[type as ExceptionType] ?? type;
+  }
+
+  getStatusLabel(status: string): string {
+    return STATUS_LABELS[status as keyof typeof STATUS_LABELS] ?? status;
+  }
+
+  getStatusColor(status: string): string {
+    const color = STATUS_COLORS[status as keyof typeof STATUS_COLORS] ?? '#6b7280';
+    return color;
+  }
+
+  getStatusBg(status: string): string {
+    const map: Record<string, string> = {
+      pending: '#fffbeb',
+      coordinator_approved: '#eff6ff',
+      approved: '#f0fdf4',
+      rejected: '#fef2f2',
+    };
+    return map[status] ?? '#f3f4f6';
+  }
+
+  private resetForm(): void {
+    this.form = {
+      employee_id: '',
+      exception_type: '',
+      start_date: '',
+      end_date: '',
+      description: '',
+    };
+    this.submitError.set(null);
+    this.dateError.set(null);
+  }
+}


### PR DESCRIPTION
## Summary

- Adds Phase 5 permission request module: `MyRequestsComponent` (/requests) for employees to submit requests, and `AdminPermissionRequestsComponent` (/admin/permission-requests) for coordinadores/directors/admins to approve or reject with notes
- Adds Phase 6 real-time notification bell: `WebSocketNotificationService` (ws/wss, ping-pong keepalive, exponential backoff reconnect), `NotificationService` (HTTP), and `NotificationBellComponent` (bell + badge + dropdown) — embedded in all 9 admin page headers
- Updates `UserRole` type to match backend enum: `admin | director | coordinador | secretaria | catedratico`
- Connects/disconnects WebSocket on login/logout via `AuthService`

## Test plan

- [ ] Login as `coordinador` → navigate to /admin/permission-requests → confirm "Aprobar/Rechazar" buttons visible on `pending` requests
- [ ] Login as `director` → confirm buttons visible on `coordinator_approved` requests
- [ ] Submit a new request at /requests with a start_date < today+7 → confirm inline validation error
- [ ] Submit with valid dates → confirm card appears in the list after POST
- [ ] Approve a request → confirm status badge updates to `coordinator_approved` or `approved`
- [ ] Reject a request → confirm rejection_reason displayed on card
- [ ] Notification bell shows unread count badge; click → dropdown renders last notifications
- [ ] Mark single notification as read → unread style disappears
- [ ] "Marcar todas como leídas" → all notifications lose unread style
- [ ] WebSocket delivers a new notification → bell badge increments without page refresh
- [ ] Logout → WebSocket disconnects (check browser DevTools WS tab)