### PR TITLE
fix(kiosk): prioritize geolocation rejection messages

### DIFF
--- a/backend/app/api/v1/endpoints/attendance.py
+++ b/backend/app/api/v1/endpoints/attendance.py
@@ -83,6 +83,19 @@ def _reject_if_outside_perimeter(distance: float | None) -> None:
     )
 
 
+def _reject_if_not_live(face_service: FaceRecognitionService, embeddings: list) -> None:
+    """Reject static/spoofed frames after identity and geolocation are valid."""
+    if len(embeddings) < 2:
+        return
+
+    is_live, variance = face_service.check_liveness_from_embeddings(embeddings)
+    if not is_live:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Liveness check failed: static image detected. Please use your real face.",
+        )
+
+
 @router.post(
     "/check-in",
     response_model=AttendanceResponse,
@@ -135,15 +148,6 @@ async def check_in(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="No face detected in the provided images",
         )
-
-    # Liveness check: require variance between frames
-    if len(all_embeddings) >= 2:
-        is_live, variance = face_service.check_liveness_from_embeddings(all_embeddings)
-        if not is_live:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Liveness check failed: static image detected. Please use your real face.",
-            )
 
     query_embedding = all_embeddings[0]
 
@@ -200,6 +204,8 @@ async def check_in(
 
     if not geo_valid:
         _reject_if_outside_perimeter(distance)
+
+    _reject_if_not_live(face_service, all_embeddings)
 
     attendance.check_in = now
     attendance.check_in_confidence = confidence
@@ -298,15 +304,6 @@ async def check_out(
             detail="No face detected in the provided images",
         )
 
-    # Liveness check: require variance between frames
-    if len(all_embeddings) >= 2:
-        is_live, variance = face_service.check_liveness_from_embeddings(all_embeddings)
-        if not is_live:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Liveness check failed: static image detected. Please use your real face.",
-            )
-
     query_embedding = all_embeddings[0]
 
     match = await face_service.find_best_match(db, query_embedding)
@@ -359,6 +356,8 @@ async def check_out(
 
     if not geo_valid:
         _reject_if_outside_perimeter(distance)
+
+    _reject_if_not_live(face_service, all_embeddings)
 
     attendance.check_out = now
     attendance.check_out_confidence = confidence

--- a/backend/tests/test_attendance_endpoints.py
+++ b/backend/tests/test_attendance_endpoints.py
@@ -37,6 +37,10 @@ def allow_liveness(mock_face_service, variance: float = 0.01):
     mock_face_service.check_liveness_from_embeddings.return_value = (True, variance)
 
 
+def reject_liveness(mock_face_service, variance: float = 0.0):
+    mock_face_service.check_liveness_from_embeddings.return_value = (False, variance)
+
+
 def mock_db_execute_result(return_values: list):
     """
     Helper to mock db.execute() with multiple queries.
@@ -243,7 +247,7 @@ class TestCheckInEndpoint:
     async def test_checkin_without_gps_coordinates_is_rejected(
         self, mock_db, mock_employee, mock_location
     ):
-        """Should reject check-in when GPS coordinates are missing."""
+        """Should reject check-in when GPS coordinates are missing before liveness."""
         # Arrange
         request = AttendanceCheckIn(
             images=THREE_IMAGES,
@@ -254,7 +258,7 @@ class TestCheckInEndpoint:
         with patch("app.api.v1.endpoints.attendance.FaceRecognitionService") as mock_fr:
             mock_face_service = mock_fr.return_value
             mock_face_service.get_face_embedding.return_value = [0.1, 0.2, 0.3]
-            allow_liveness(mock_face_service)
+            reject_liveness(mock_face_service)
             mock_face_service.find_best_match = AsyncMock(
                 return_value=(mock_employee, 0.95)
             )
@@ -269,12 +273,13 @@ class TestCheckInEndpoint:
             # Assert
             assert exc_info.value.status_code == 400
             assert "GPS" in exc_info.value.detail
+            mock_face_service.check_liveness_from_embeddings.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_checkin_outside_permitted_area_is_rejected(
         self, mock_db, mock_employee, mock_location
     ):
-        """Should reject check-in if employee is outside permitted radius."""
+        """Should reject check-in outside radius before liveness."""
         # Arrange - coordinates far from location
         request = AttendanceCheckIn(
             images=THREE_IMAGES,
@@ -286,7 +291,7 @@ class TestCheckInEndpoint:
         with patch("app.api.v1.endpoints.attendance.FaceRecognitionService") as mock_fr:
             mock_face_service = mock_fr.return_value
             mock_face_service.get_face_embedding.return_value = [0.1, 0.2, 0.3]
-            allow_liveness(mock_face_service)
+            reject_liveness(mock_face_service)
             mock_face_service.find_best_match = AsyncMock(
                 return_value=(mock_employee, 0.95)
             )
@@ -303,6 +308,7 @@ class TestCheckInEndpoint:
             # Assert
             assert exc_info.value.status_code == 403
             assert "Outside permitted area" in exc_info.value.detail
+            mock_face_service.check_liveness_from_embeddings.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_already_checked_in_today(
@@ -345,14 +351,26 @@ class TestCheckInEndpoint:
             assert response.check_in == mock_attendance_record.check_in
 
     @pytest.mark.asyncio
-    async def test_reject_liveness_failure(self, mock_db):
-        """Should reject static frames that fail liveness detection."""
-        request = AttendanceCheckIn(images=THREE_IMAGES)
+    async def test_reject_liveness_failure_with_valid_geofence(
+        self, mock_db, mock_employee, mock_location
+    ):
+        """Should reject static frames when GPS/geofence are valid."""
+        request = AttendanceCheckIn(
+            images=THREE_IMAGES,
+            latitude=-34.603722,
+            longitude=-58.381592,
+        )
 
         with patch("app.api.v1.endpoints.attendance.FaceRecognitionService") as mock_fr:
             mock_face_service = mock_fr.return_value
             mock_face_service.get_face_embedding.return_value = [0.1, 0.2, 0.3]
-            mock_face_service.check_liveness_from_embeddings.return_value = (False, 0.0)
+            reject_liveness(mock_face_service)
+            mock_face_service.find_best_match = AsyncMock(
+                return_value=(mock_employee, 0.95)
+            )
+            mock_db.execute = AsyncMock(
+                side_effect=mock_db_execute_result([None, mock_location])
+            )
 
             with pytest.raises(HTTPException) as exc_info:
                 await check_in(mock_db, request)
@@ -498,7 +516,7 @@ class TestCheckOutEndpoint:
         with patch("app.api.v1.endpoints.attendance.FaceRecognitionService") as mock_fr:
             mock_face_service = mock_fr.return_value
             mock_face_service.get_face_embedding.return_value = [0.1, 0.2, 0.3]
-            allow_liveness(mock_face_service)
+            reject_liveness(mock_face_service)
             mock_face_service.find_best_match = AsyncMock(
                 return_value=(mock_employee, 0.95)
             )
@@ -517,6 +535,65 @@ class TestCheckOutEndpoint:
             # Assert
             assert exc_info.value.status_code == 403
             assert "Outside permitted area" in exc_info.value.detail
+            mock_face_service.check_liveness_from_embeddings.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_checkout_without_gps_coordinates_is_rejected_before_liveness(
+        self, mock_db, mock_employee, mock_attendance_record
+    ):
+        """Should reject check-out missing GPS before liveness."""
+        request = AttendanceCheckOut(images=THREE_IMAGES)
+        mock_attendance_record.check_in = datetime.utcnow()
+
+        with patch("app.api.v1.endpoints.attendance.FaceRecognitionService") as mock_fr:
+            mock_face_service = mock_fr.return_value
+            mock_face_service.get_face_embedding.return_value = [0.1, 0.2, 0.3]
+            reject_liveness(mock_face_service)
+            mock_face_service.find_best_match = AsyncMock(
+                return_value=(mock_employee, 0.95)
+            )
+            mock_db.execute = AsyncMock(
+                side_effect=mock_db_execute_result([mock_attendance_record])
+            )
+
+            with pytest.raises(HTTPException) as exc_info:
+                await check_out(mock_db, request)
+
+            assert exc_info.value.status_code == 400
+            assert "GPS" in exc_info.value.detail
+            mock_face_service.check_liveness_from_embeddings.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_checkout_liveness_failure_with_valid_geofence(
+        self, mock_db, mock_employee, mock_location, mock_attendance_record
+    ):
+        """Should reject static check-out frames when GPS/geofence are valid."""
+        request = AttendanceCheckOut(
+            images=THREE_IMAGES,
+            latitude=-34.603722,
+            longitude=-58.381592,
+        )
+        mock_attendance_record.check_in = datetime.utcnow()
+        mock_attendance_record.geo_validated = True
+
+        with patch("app.api.v1.endpoints.attendance.FaceRecognitionService") as mock_fr:
+            mock_face_service = mock_fr.return_value
+            mock_face_service.get_face_embedding.return_value = [0.1, 0.2, 0.3]
+            reject_liveness(mock_face_service)
+            mock_face_service.find_best_match = AsyncMock(
+                return_value=(mock_employee, 0.95)
+            )
+            mock_db.execute = AsyncMock(
+                side_effect=mock_db_execute_result(
+                    [mock_attendance_record, mock_location]
+                )
+            )
+
+            with pytest.raises(HTTPException) as exc_info:
+                await check_out(mock_db, request)
+
+            assert exc_info.value.status_code == 400
+            assert "Liveness check failed" in exc_info.value.detail
 
 
 class TestAttendanceListEndpoints:

--- a/frontend/src/app/features/kiosk/kiosk.component.spec.ts
+++ b/frontend/src/app/features/kiosk/kiosk.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { type ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
 import { signal } from '@angular/core';
 
@@ -129,7 +129,7 @@ describe('KioskComponent', () => {
     expect(component.mode()).toBe('error');
   });
 
-  it('should clear the previous liveness error as soon as a new scan starts', async () => {
+  it('should continue to GPS and submit attendance when client liveness is inconclusive', async () => {
     fixture.detectChanges();
     livenessService.analyzeLiveness.and.returnValue(
       Promise.resolve({
@@ -138,29 +138,36 @@ describe('KioskComponent', () => {
         framesAnalyzed: 3,
       }),
     );
-
-    await component.scan();
-
-    expect(component.mode()).toBe('error');
-    expect(component.errorMessage()).toContain('imagen estática');
-
-    let resolveSecondCapture!: (images: string[]) => void;
-    cameraService.captureFrames.and.returnValue(
-      new Promise((resolve) => {
-        resolveSecondCapture = resolve;
+    geolocationService.isSupported.and.returnValue(true);
+    geolocationService.getCurrentPosition.and.returnValue(
+      of({
+        latitude: 14.3,
+        longitude: -89.9,
+        accuracy: 5,
       }),
     );
 
-    void component.scan();
+    await component.scan();
 
-    expect(component.mode()).toBe('scanning');
-    expect(component.errorMessage()).toBe('');
-
-    resolveSecondCapture(['img1', 'img2', 'img3']);
+    expect(livenessService.analyzeLiveness).toHaveBeenCalled();
+    expect(geolocationService.getCurrentPosition).toHaveBeenCalled();
+    expect(attendanceService.checkIn).toHaveBeenCalledWith({
+      images: ['img1', 'img2', 'img3'],
+      latitude: 14.3,
+      longitude: -89.9,
+    });
+    expect(component.mode()).toBe('success');
   });
 
   it('should translate outside-perimeter backend errors and preserve the distance', async () => {
     fixture.detectChanges();
+    livenessService.analyzeLiveness.and.returnValue(
+      Promise.resolve({
+        isLive: false,
+        variance: 1,
+        framesAnalyzed: 3,
+      }),
+    );
     geolocationService.isSupported.and.returnValue(true);
     geolocationService.getCurrentPosition.and.returnValue(
       of({

--- a/frontend/src/app/features/kiosk/kiosk.component.ts
+++ b/frontend/src/app/features/kiosk/kiosk.component.ts
@@ -1,18 +1,18 @@
 import {
   Component,
-  OnInit,
-  OnDestroy,
+  type OnInit,
+  type OnDestroy,
   inject,
   signal,
   ViewChild,
-  ElementRef,
+  type ElementRef,
   computed,
   afterNextRender,
   isDevMode,
 } from '@angular/core';
 import { CommonModule, DatePipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
-import { SwUpdate, VersionReadyEvent } from '@angular/service-worker';
+import { SwUpdate, type VersionReadyEvent } from '@angular/service-worker';
 import { filter } from 'rxjs/operators';
 import { CameraService } from '../../core/services/camera.service';
 import { AttendanceService } from '../../core/services/attendance.service';
@@ -20,9 +20,9 @@ import { GeolocationService } from '../../core/services/geolocation.service';
 import { LocationService } from '../../core/services/location.service';
 import { PlatformService } from '../../core/services/platform.service';
 import { LivenessService } from '../../core/services/liveness.service';
-import { GeoPosition } from '../../core/models/geolocation.model';
-import { Location as AppLocation } from '../../core/models/location.model';
-import { AttendanceRecord } from '../../core/models/attendance.model';
+import type { GeoPosition } from '../../core/models/geolocation.model';
+import type { Location as AppLocation } from '../../core/models/location.model';
+import type { AttendanceRecord } from '../../core/models/attendance.model';
 
 const KIOSK_LOCATION_KEY = 'kiosk_location_id';
 const KIOSK_RESULT_RESET_DELAY_MS = 12000;
@@ -1093,18 +1093,9 @@ export class KioskComponent implements OnInit, OnDestroy {
       return;
     }
 
-    // Client-side liveness check: detect static photos before sending to server
-    const livenessResult = await this.livenessService.analyzeLiveness(images);
-    if (!livenessResult.isLive) {
-      this.showError({
-        title: 'Rostro real requerido',
-        message: 'Se detectó una imagen estática. Por favor usá tu rostro real frente a la cámara.',
-        help: 'No uses fotos, pantallas ni impresiones. Mirá directo a la cámara del kiosk.',
-      });
-      this.mode.set('error');
-      this.resetAfterDelay();
-      return;
-    }
+    // Client-side liveness is advisory only. The backend remains authoritative,
+    // after GPS/geofence checks, so users see the real rejection reason.
+    await this.livenessService.analyzeLiveness(images);
 
     // Always request a fresh GPS position at scan time.
     // Falls back to the cached position only if the fresh request fails


### PR DESCRIPTION
Closes #18

## Summary
- Make client-side liveness advisory so GPS/backend can determine the real rejection reason.
- Prioritize backend GPS/geofence validation before final liveness rejection after employee identification.
- Keep backend liveness enforced when geolocation is valid.

## Changes
| File | Change |
|------|--------|
| `backend/app/api/v1/endpoints/attendance.py` | Reorders attendance validation so GPS/geofence errors are returned before liveness when applicable. |
| `backend/tests/test_attendance_endpoints.py` | Adds coverage for GPS/outside-perimeter priority and liveness still rejecting with valid geofence. |
| `frontend/src/app/features/kiosk/kiosk.component.ts` | Makes client liveness advisory/fail-open before API submission. |
| `frontend/src/app/features/kiosk/kiosk.component.spec.ts` | Covers client liveness fail-open and preserves geolocation backend messages. |

## Test Plan
- [x] `git diff --check`
- [x] `cd backend && PYTHONPATH=. .venv/bin/pytest -q` → 40 passed
- [x] `cd frontend && npx ng test --watch=false --browsers=ChromeHeadless` → TOTAL: 112 SUCCESS
- [x] `cd frontend && npm run build` → success with existing budget/CommonJS warnings

## Review size
- 4 files changed, 137 insertions, 63 deletions.
- Under 4000-line limit; chained PRs not needed.
