### PR TITLE
fix(kiosk): clarify GPS failure guidance

### DIFF
--- a/frontend/src/app/features/kiosk/kiosk.component.spec.ts
+++ b/frontend/src/app/features/kiosk/kiosk.component.spec.ts
@@ -129,6 +129,59 @@ describe('KioskComponent', () => {
     expect(component.mode()).toBe('error');
   });
 
+  it('should explain when browser location permission is denied', async () => {
+    fixture.detectChanges();
+    geolocationService.getCurrentPosition.and.returnValue(
+      throwError(() => ({
+        code: 'PERMISSION_DENIED',
+        message: 'Permiso de ubicación denegado',
+        hint: 'Permití ubicación para asistencia.sistemaslab.dev en el navegador.',
+      })),
+    );
+
+    await component.scan();
+
+    expect(attendanceService.checkIn).not.toHaveBeenCalled();
+    expect(component.mode()).toBe('error');
+    expect(component.errorTitle()).toBe('Permiso de ubicación denegado');
+    expect(component.errorMessage()).toContain('no tiene permiso');
+    expect(component.errorHelp()).toContain('Permití ubicación');
+  });
+
+  it('should explain when device GPS is unavailable', async () => {
+    fixture.detectChanges();
+    geolocationService.getCurrentPosition.and.returnValue(
+      throwError(() => ({
+        code: 'POSITION_UNAVAILABLE',
+        message: 'GPS no disponible en este dispositivo',
+      })),
+    );
+
+    await component.scan();
+
+    expect(attendanceService.checkIn).not.toHaveBeenCalled();
+    expect(component.mode()).toBe('error');
+    expect(component.errorTitle()).toBe('GPS no disponible');
+    expect(component.errorHelp()).toContain('Activá la ubicación/GPS');
+  });
+
+  it('should explain when GPS acquisition times out', async () => {
+    fixture.detectChanges();
+    geolocationService.getCurrentPosition.and.returnValue(
+      throwError(() => ({
+        code: 'TIMEOUT',
+        message: 'No se pudo obtener la ubicación a tiempo',
+      })),
+    );
+
+    await component.scan();
+
+    expect(attendanceService.checkIn).not.toHaveBeenCalled();
+    expect(component.mode()).toBe('error');
+    expect(component.errorTitle()).toBe('GPS sin respuesta');
+    expect(component.errorHelp()).toContain('zona con señal');
+  });
+
   it('should continue to GPS and submit attendance when client liveness is inconclusive', async () => {
     fixture.detectChanges();
     livenessService.analyzeLiveness.and.returnValue(

--- a/frontend/src/app/features/kiosk/kiosk.component.ts
+++ b/frontend/src/app/features/kiosk/kiosk.component.ts
@@ -1114,17 +1114,12 @@ export class KioskComponent implements OnInit, OnDestroy {
           error: (err) => reject(err),
         });
       });
-    } catch {
+    } catch (error) {
       // Fresh GPS failed — use cached position if available
       if (!this.currentPosition) {
         this.geoStatus.set('error');
         this.geoError.set('No se pudo obtener la ubicación GPS real del dispositivo.');
-        this.showError({
-          title: 'Ubicación requerida',
-          message:
-            'Se requiere GPS real para marcar asistencia. Verificá los permisos de ubicación.',
-          help: 'Activá la ubicación del dispositivo y permití el acceso desde el navegador.',
-        });
+        this.showError(this.toGeolocationErrorContent(error));
         this.mode.set('error');
         this.resetAfterDelay();
         return;
@@ -1170,6 +1165,42 @@ export class KioskComponent implements OnInit, OnDestroy {
     this.errorTitle.set(content.title);
     this.errorMessage.set(content.message);
     this.errorHelp.set(content.help);
+  }
+
+  private toGeolocationErrorContent(error: unknown): KioskErrorContent {
+    const geoError = error as { code?: string; message?: string; hint?: string };
+
+    if (geoError?.code === 'PERMISSION_DENIED') {
+      return {
+        title: 'Permiso de ubicación denegado',
+        message: 'El navegador no tiene permiso para usar tu ubicación GPS.',
+        help:
+          geoError.hint ??
+          'Abrí los permisos del sitio y permití ubicación para asistencia.sistemaslab.dev.',
+      };
+    }
+
+    if (geoError?.code === 'TIMEOUT') {
+      return {
+        title: 'GPS sin respuesta',
+        message: 'No se pudo obtener tu ubicación GPS a tiempo.',
+        help: 'Activá la ubicación del dispositivo, acercate a una zona con señal y volvé a intentar.',
+      };
+    }
+
+    if (geoError?.code === 'POSITION_UNAVAILABLE' || geoError?.code === 'NOT_SUPPORTED') {
+      return {
+        title: 'GPS no disponible',
+        message: 'No se pudo obtener una ubicación GPS real desde este dispositivo.',
+        help: 'Activá la ubicación/GPS del dispositivo y permití el acceso desde el navegador.',
+      };
+    }
+
+    return {
+      title: 'Ubicación requerida',
+      message: 'Se requiere GPS real para marcar asistencia.',
+      help: 'Activá la ubicación del dispositivo y permití el acceso desde el navegador.',
+    };
   }
 
   private toKioskErrorContent(detail: unknown): KioskErrorContent {


### PR DESCRIPTION
Closes #22

## Summary
- Show specific kiosk guidance when scan-time GPS acquisition fails.
- Distinguish denied permission, GPS unavailable/unsupported, and timeout cases.
- Keep attendance submission blocked when no real GPS position is available.

## Changes
| File | Change |
|------|--------|
| `frontend/src/app/features/kiosk/kiosk.component.ts` | Maps geolocation errors to specific user-facing instructions. |
| `frontend/src/app/features/kiosk/kiosk.component.spec.ts` | Adds coverage for permission denied, unavailable GPS, and timeout messages. |

## Test Plan
- [x] `cd frontend && npx ng test --watch=false --browsers=ChromeHeadless --include='src/app/features/kiosk/kiosk.component.spec.ts'` → TOTAL: 7 SUCCESS
- [x] `cd frontend && npx ng test --watch=false --browsers=ChromeHeadless` → TOTAL: 115 SUCCESS
- [x] `cd frontend && npm run build` → success with existing budget/CommonJS warnings
- [x] `git diff --check`

## Review size
- 2 files changed, 91 insertions, 7 deletions.
- Under 4000-line limit; chained PRs not needed.
