### PR TITLE
fix(kiosk): require GPS and camera hardware

### DIFF
--- a/frontend/android/app/src/main/AndroidManifest.xml
+++ b/frontend/android/app/src/main/AndroidManifest.xml
@@ -42,7 +42,8 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     
-    <!-- Camera feature (optional but recommended for Play Store filtering) -->
-    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <!-- Kiosk production devices must provide camera and GPS hardware. -->
+    <uses-feature android:name="android.hardware.camera" android:required="true" />
+    <uses-feature android:name="android.hardware.location.gps" android:required="true" />
     <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
 </manifest>

--- a/frontend/src/app/core/services/camera.service.spec.ts
+++ b/frontend/src/app/core/services/camera.service.spec.ts
@@ -10,6 +10,13 @@ describe('CameraService', () => {
   let mockTrack: jasmine.SpyObj<MediaStreamTrack>;
 
   beforeEach(() => {
+    if (!navigator.mediaDevices?.getUserMedia) {
+      Object.defineProperty(navigator, 'mediaDevices', {
+        value: { getUserMedia: () => Promise.reject(new Error('Not mocked')) },
+        configurable: true,
+      });
+    }
+
     // Mock PlatformService
     const platformSpy = jasmine.createSpyObj('PlatformService', ['jpegQuality', 'isNative']);
     platformSpy.jpegQuality.and.returnValue(0.8);
@@ -37,6 +44,42 @@ describe('CameraService', () => {
 
   afterEach(() => {
     service.stop();
+  });
+
+  describe('isSupported', () => {
+    let mediaDevicesDescriptor: PropertyDescriptor | undefined;
+
+    beforeEach(() => {
+      mediaDevicesDescriptor = Object.getOwnPropertyDescriptor(navigator, 'mediaDevices');
+    });
+
+    afterEach(() => {
+      if (mediaDevicesDescriptor) {
+        Object.defineProperty(navigator, 'mediaDevices', mediaDevicesDescriptor);
+      }
+    });
+
+    it('should return true when getUserMedia is available', () => {
+      expect(service.isSupported()).toBe(true);
+    });
+
+    it('should return false when mediaDevices is unavailable', () => {
+      Object.defineProperty(navigator, 'mediaDevices', {
+        value: undefined,
+        configurable: true,
+      });
+
+      expect(service.isSupported()).toBe(false);
+    });
+
+    it('should return false when getUserMedia is unavailable', () => {
+      Object.defineProperty(navigator, 'mediaDevices', {
+        value: {},
+        configurable: true,
+      });
+
+      expect(service.isSupported()).toBe(false);
+    });
   });
 
   describe('start', () => {

--- a/frontend/src/app/core/services/camera.service.ts
+++ b/frontend/src/app/core/services/camera.service.ts
@@ -46,6 +46,10 @@ export class CameraService {
   readonly error = this.hasError.asReadonly();
   readonly capturing = this.isCapturing.asReadonly();
 
+  isSupported(): boolean {
+    return typeof navigator !== 'undefined' && !!navigator.mediaDevices?.getUserMedia;
+  }
+
   async start(videoEl: HTMLVideoElement, config: Partial<CameraConfig> = {}): Promise<void> {
     const finalConfig = { 
       ...DEFAULT_CONFIG, 

--- a/frontend/src/app/features/attendance/attendance-scan.component.spec.ts
+++ b/frontend/src/app/features/attendance/attendance-scan.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { type ComponentFixture, TestBed } from '@angular/core/testing';
 import { AttendanceScanComponent } from './attendance-scan.component';
 import { CameraService } from '../../core/services/camera.service';
 import { GeolocationService } from '../../core/services/geolocation.service';
@@ -123,10 +123,15 @@ describe('AttendanceScanComponent', () => {
       fixture.detectChanges();
     });
 
-    it('should return true when camera is active and not capturing', () => {
+    it('should return true when camera is active, not capturing, and GPS is available', () => {
       Object.defineProperty(cameraService, 'active', { value: signal(true) });
       Object.defineProperty(cameraService, 'capturing', { value: signal(false) });
       component.cameraError.set(null);
+      component.lastGeoPosition.set({
+        latitude: -34.603722,
+        longitude: -58.381592,
+        accuracy: 10,
+      });
       component.mode.set('idle');
 
       expect(component.canScan()).toBe(true);
@@ -163,6 +168,16 @@ describe('AttendanceScanComponent', () => {
       Object.defineProperty(cameraService, 'active', { value: signal(true) });
       Object.defineProperty(cameraService, 'capturing', { value: signal(false) });
       component.cameraError.set('Camera error');
+      component.mode.set('idle');
+
+      expect(component.canScan()).toBe(false);
+    });
+
+    it('should return false if GPS position is missing', () => {
+      Object.defineProperty(cameraService, 'active', { value: signal(true) });
+      Object.defineProperty(cameraService, 'capturing', { value: signal(false) });
+      component.cameraError.set(null);
+      component.lastGeoPosition.set(null);
       component.mode.set('idle');
 
       expect(component.canScan()).toBe(false);
@@ -330,6 +345,16 @@ describe('AttendanceScanComponent', () => {
 
       expect(component.mode()).toBe('error');
       expect(component.errorMessage()).toContain('Error de conexión');
+    });
+
+    it('should not call backend when GPS position is missing', async () => {
+      component.lastGeoPosition.set(null);
+
+      await component.handleScan();
+
+      expect(cameraService.captureFrames).not.toHaveBeenCalled();
+      expect(attendanceService.checkIn).not.toHaveBeenCalled();
+      expect(component.mode()).toBe('idle');
     });
 
     it('should handle capture failure', async () => {

--- a/frontend/src/app/features/kiosk/kiosk.component.spec.ts
+++ b/frontend/src/app/features/kiosk/kiosk.component.spec.ts
@@ -23,10 +23,11 @@ describe('KioskComponent', () => {
   beforeEach(async () => {
     localStorage.clear();
 
-    const cameraSpy = jasmine.createSpyObj('CameraService', ['start', 'stop', 'captureFrames'], {
+    const cameraSpy = jasmine.createSpyObj('CameraService', ['isSupported', 'start', 'stop', 'captureFrames'], {
       active: signal(true),
       capturing: signal(false),
     });
+    cameraSpy.isSupported.and.returnValue(true);
     cameraSpy.start.and.returnValue(Promise.resolve());
     cameraSpy.captureFrames.and.returnValue(Promise.resolve(['img1', 'img2', 'img3']));
 
@@ -119,6 +120,26 @@ describe('KioskComponent', () => {
     fixture?.destroy();
   });
 
+  it('should show a GPS error when browser geolocation is unsupported', () => {
+    fixture.detectChanges();
+
+    expect(geolocationService.isSupported).toHaveBeenCalled();
+    expect(component.geoStatus()).toBe('error');
+    expect(component.geoError()).toContain('geolocalización');
+  });
+
+  it('should block kiosk camera when camera API is unsupported', async () => {
+    cameraService.isSupported.and.returnValue(false);
+
+    fixture.detectChanges();
+    await component.startCamera();
+
+    expect(cameraService.start).not.toHaveBeenCalled();
+    expect(component.mode()).toBe('error');
+    expect(component.errorTitle()).toBe('Cámara requerida');
+    expect(component.errorHelp()).toContain('tablet Android con cámara y GPS');
+  });
+
   it('should not submit attendance using configured location when real GPS is unavailable', async () => {
     fixture.detectChanges();
 
@@ -127,6 +148,28 @@ describe('KioskComponent', () => {
     expect(cameraService.captureFrames).toHaveBeenCalled();
     expect(attendanceService.checkIn).not.toHaveBeenCalled();
     expect(component.mode()).toBe('error');
+  });
+
+  it('should reject stale cached GPS when fresh scan-time GPS fails', async () => {
+    fixture.detectChanges();
+    (component as any).currentPosition = {
+      latitude: 14.3,
+      longitude: -89.9,
+      accuracy: 5,
+    };
+    (component as any).currentPositionTimestamp = Date.now() - 6 * 60 * 1000;
+    geolocationService.getCurrentPosition.and.returnValue(
+      throwError(() => ({
+        code: 'TIMEOUT',
+        message: 'No se pudo obtener la ubicación a tiempo',
+      })),
+    );
+
+    await component.scan();
+
+    expect(attendanceService.checkIn).not.toHaveBeenCalled();
+    expect(component.mode()).toBe('error');
+    expect(component.errorTitle()).toBe('GPS sin respuesta');
   });
 
   it('should explain when browser location permission is denied', async () => {

--- a/frontend/src/app/features/kiosk/kiosk.component.ts
+++ b/frontend/src/app/features/kiosk/kiosk.component.ts
@@ -923,6 +923,8 @@ export class KioskComponent implements OnInit, OnDestroy {
   readonly geoStatus = signal<GeoStatus>('idle');
   readonly geoError = signal<string>('');
   private currentPosition: GeoPosition | null = null;
+  private currentPositionTimestamp: number | null = null;
+  private readonly maxCachedPositionAgeMs = 5 * 60 * 1000;
 
   readonly kioskLocation = signal<AppLocation | null>(null);
   readonly availableLocations = signal<AppLocation[]>([]);
@@ -988,11 +990,13 @@ export class KioskComponent implements OnInit, OnDestroy {
     this.geolocationService.getCurrentPosition().subscribe({
       next: (position) => {
         this.currentPosition = position;
+        this.currentPositionTimestamp = Date.now();
         this.geoStatus.set('success');
         this.geoError.set('');
       },
       error: () => {
         this.currentPosition = null;
+        this.currentPositionTimestamp = null;
         this.geoStatus.set('error');
         this.geoError.set('No se pudo obtener la ubicación GPS real del dispositivo.');
       },
@@ -1013,6 +1017,7 @@ export class KioskComponent implements OnInit, OnDestroy {
     localStorage.removeItem(KIOSK_LOCATION_KEY);
     this.kioskLocation.set(null);
     this.currentPosition = null;
+    this.currentPositionTimestamp = null;
     this.geoStatus.set('idle');
     this.geoError.set('');
     this.showLocationPicker.set(false);
@@ -1060,6 +1065,16 @@ export class KioskComponent implements OnInit, OnDestroy {
   }
 
   async startCamera(): Promise<void> {
+    if (!this.cameraService.isSupported()) {
+      this.showError({
+        title: 'Cámara requerida',
+        message: 'Este dispositivo o navegador no tiene una cámara disponible para el kiosk.',
+        help: 'Usá una tablet Android con cámara y GPS habilitados para operar el kiosk.',
+      });
+      this.mode.set('error');
+      return;
+    }
+
     try {
       await this.cameraService.start(this.videoElement.nativeElement);
     } catch (error) {
@@ -1107,6 +1122,7 @@ export class KioskComponent implements OnInit, OnDestroy {
         this.geolocationService.getCurrentPosition().subscribe({
           next: (pos) => {
             this.currentPosition = pos;
+            this.currentPositionTimestamp = Date.now();
             this.geoStatus.set('success');
             this.geoError.set('');
             resolve(pos);
@@ -1115,8 +1131,10 @@ export class KioskComponent implements OnInit, OnDestroy {
         });
       });
     } catch (error) {
-      // Fresh GPS failed — use cached position if available
-      if (!this.currentPosition) {
+      // Fresh GPS failed — use cached position only if it is recent enough.
+      if (!this.isCurrentPositionFresh()) {
+        this.currentPosition = null;
+        this.currentPositionTimestamp = null;
         this.geoStatus.set('error');
         this.geoError.set('No se pudo obtener la ubicación GPS real del dispositivo.');
         this.showError(this.toGeolocationErrorContent(error));
@@ -1124,8 +1142,16 @@ export class KioskComponent implements OnInit, OnDestroy {
         this.resetAfterDelay();
         return;
       }
-      // currentPosition already set — use it as fallback
       position = this.currentPosition;
+    }
+
+    if (!position) {
+      this.geoStatus.set('error');
+      this.geoError.set('No se pudo obtener la ubicación GPS real del dispositivo.');
+      this.showError(this.toGeolocationErrorContent(null));
+      this.mode.set('error');
+      this.resetAfterDelay();
+      return;
     }
 
     const request: { images: string[]; latitude?: number; longitude?: number } = {
@@ -1165,6 +1191,14 @@ export class KioskComponent implements OnInit, OnDestroy {
     this.errorTitle.set(content.title);
     this.errorMessage.set(content.message);
     this.errorHelp.set(content.help);
+  }
+
+  private isCurrentPositionFresh(): boolean {
+    return (
+      this.currentPosition !== null &&
+      this.currentPositionTimestamp !== null &&
+      Date.now() - this.currentPositionTimestamp <= this.maxCachedPositionAgeMs
+    );
   }
 
   private toGeolocationErrorContent(error: unknown): KioskErrorContent {


### PR DESCRIPTION
Closes #25

## Summary
- Require camera and GPS hardware for Android kiosk production devices.
- Add runtime camera capability checks for kiosk/web.
- Keep kiosk blocked when geolocation is unsupported or scan-time GPS cannot be acquired.
- Reject stale cached GPS positions older than 5 minutes.
- Strengthen mobile scan tests so attendance cannot be submitted without active camera and GPS.

## Changes
| File | Change |
|------|--------|
| `frontend/android/app/src/main/AndroidManifest.xml` | Marks camera and GPS hardware as required for Android devices. |
| `frontend/src/app/core/services/camera.service.ts` | Adds `isSupported()` runtime camera API check. |
| `frontend/src/app/features/kiosk/kiosk.component.ts` | Blocks unsupported camera and enforces cached GPS freshness. |
| specs | Adds coverage for camera support, GPS support, stale GPS, and mobile scan gating. |

## Test Plan
- [x] `cd frontend && npx ng test --watch=false --browsers=ChromeHeadless --include='src/app/features/kiosk/kiosk.component.spec.ts'` → TOTAL: 10 SUCCESS
- [x] `cd frontend && npx ng test --watch=false --browsers=ChromeHeadless` → TOTAL: 123 SUCCESS
- [x] `cd frontend && npm run build` → success with existing budget/CommonJS warnings
- [x] `git diff --check`

## Review size
- 6 tracked files changed; under the 4000-line split threshold.
