### PR TITLE
fix(i18n): prevent browser mistranslation

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "build": "ng build",
     "build:prod": "ng build --configuration production",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "test:index-language": "node scripts/verify-index-language.mjs"
   },
   "prettier": {
     "printWidth": 100,

--- a/frontend/scripts/verify-index-language.mjs
+++ b/frontend/scripts/verify-index-language.mjs
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const indexPath = resolve(__dirname, '../src/index.html');
+const indexHtml = readFileSync(indexPath, 'utf8');
+
+const checks = [
+  {
+    name: 'html lang must be Spanish',
+    valid: /<html\s+[^>]*lang="es"/.test(indexHtml),
+  },
+  {
+    name: 'browser translation must be disabled for fixed Spanish UI labels',
+    valid: /<html\s+[^>]*translate="no"/.test(indexHtml),
+  },
+  {
+    name: 'Google Translate must be disabled',
+    valid: /<meta\s+name="google"\s+content="notranslate"\s*>/.test(indexHtml),
+  },
+];
+
+const failures = checks.filter((check) => !check.valid);
+
+if (failures.length > 0) {
+  console.error('Index language verification failed:');
+  for (const failure of failures) {
+    console.error(`- ${failure.name}`);
+  }
+  process.exit(1);
+}
+
+console.log('Index language verification passed.');

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -1,7 +1,8 @@
 <!doctype html>
-<html lang="en">
+<html lang="es" translate="no">
 <head>
   <meta charset="utf-8">
+  <meta name="google" content="notranslate">
   <title>Sistema Biometrico</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1">


### PR DESCRIPTION
Closes #27

## Summary
- Declare the app document language as Spanish.
- Disable browser/Google auto-translation for fixed Spanish UI labels.
- Add a verification script so `lang="es"`, `translate="no"`, and `notranslate` stay in place.

## QA Evidence
QA screenshots showed browser mistranslation artifacts:
- `Empalados` / `Empalado` instead of `Empleados` / `Empleado`.
- `Rivalizar` instead of the Friday label.

The source labels were already Spanish; the root issue was the document declaring `lang="en"`, allowing browser translation to reinterpret Spanish labels.

## Test Plan
- [x] `cd frontend && npm run test:index-language` → passed
- [x] `cd frontend && npm run build` → success with existing budget/CommonJS warnings
- [x] `git diff --check`

## Review size
- 3 tracked files changed; under the split threshold.
