### PR TITLE
fix(rbac): add protected access foundation

### DIFF
--- a/backend/alembic/versions/202606101200_canonical_rbac_roles.py
+++ b/backend/alembic/versions/202606101200_canonical_rbac_roles.py
@@ -1,0 +1,158 @@
+"""canonical RBAC roles and bootstrap admin foundation
+
+Revision ID: 202606101200
+Revises: f1a2b3c4d5e6
+Create Date: 2026-06-10
+"""
+
+import os
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "202606101200"
+down_revision = "f1a2b3c4d5e6"
+branch_labels = None
+depends_on = None
+
+
+CANONICAL_ROLES = [
+    {"name": "ADMIN", "description": "Hidden bootstrap system administrator"},
+    {"name": "DEV", "description": "Technical RBAC and audit administration"},
+    {"name": "DECANO", "description": "Top business administration"},
+    {"name": "DUEÑO", "description": "Business owner administration"},
+    {"name": "DIRECTOR", "description": "Academic/operational direction"},
+    {"name": "ADMINISTRATIVO", "description": "Administrative operations"},
+    {"name": "CATEDRATICO", "description": "Teacher-scoped access"},
+    {"name": "ESTUDIANTE", "description": "Student self-service access"},
+    {"name": "PADRES", "description": "Parent child-scoped read access"},
+]
+
+CANONICAL_PERMISSIONS = [
+    ("users.view", "users", "view", "global", "View users"),
+    ("users.manage", "users", "manage", "global", "Manage users and role assignments"),
+    ("roles.view", "roles", "view", "global", "View roles and permissions"),
+    ("roles.manage", "roles", "manage", "global", "Manage role permissions"),
+    ("permissions.view", "permissions", "view", "global", "View permissions"),
+    ("audit.internal", "audit", "view", "global", "View internal audit and validation data"),
+]
+
+LEGACY_ROLE_MAPPING = {
+    "director": "DIRECTOR",
+    "coordinador": "ADMINISTRATIVO",
+    "secretaria": "ADMINISTRATIVO",
+    "supervisor": "ADMINISTRATIVO",
+    "catedratico": "CATEDRATICO",
+}
+
+LEGACY_ADMIN_FALLBACK_ALLOWED_ROLES = {"DECANO", "DUEÑO", "DIRECTOR", "ADMINISTRATIVO"}
+
+
+def _legacy_admin_fallback_role() -> str:
+    fallback = os.getenv("LEGACY_ADMIN_FALLBACK_ROLE", "DECANO").strip().upper()
+    if fallback not in LEGACY_ADMIN_FALLBACK_ALLOWED_ROLES:
+        raise ValueError("LEGACY_ADMIN_FALLBACK_ROLE must be a non-system business role")
+    return fallback
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    with op.get_context().autocommit_block():
+        for role in [r["name"] for r in CANONICAL_ROLES]:
+            op.execute(f"ALTER TYPE userrole ADD VALUE IF NOT EXISTS '{role}'")
+
+    for role in CANONICAL_ROLES:
+        bind.execute(
+            sa.text(
+                "INSERT INTO roles (id, name, description, is_active, created_at, updated_at) "
+                "VALUES (:id, :name, :description, true, NOW(), NOW()) "
+                "ON CONFLICT (name) DO UPDATE SET description = EXCLUDED.description, "
+                "is_active = true, updated_at = NOW()"
+            ),
+            {"id": str(uuid.uuid4()), **role},
+        )
+
+    for code, module, action, scope, description in CANONICAL_PERMISSIONS:
+        bind.execute(
+            sa.text(
+                "INSERT INTO permissions (id, code, module, action, scope, description, created_at) "
+                "VALUES (:id, :code, :module, :action, :scope, :description, NOW()) "
+                "ON CONFLICT (code) DO UPDATE SET description = EXCLUDED.description"
+            ),
+            {
+                "id": str(uuid.uuid4()),
+                "code": code,
+                "module": module,
+                "action": action,
+                "scope": scope,
+                "description": description,
+            },
+        )
+
+    bind.execute(
+        sa.text(
+            "UPDATE users SET role = CASE "
+            "WHEN role::text = 'admin' AND lower(email) = lower(:bootstrap_email) THEN 'ADMIN'::userrole "
+            "WHEN role::text = 'admin' THEN CAST(:fallback AS userrole) "
+            "WHEN role::text = 'director' THEN 'DIRECTOR'::userrole "
+            "WHEN role::text IN ('coordinador','secretaria','supervisor') THEN 'ADMINISTRATIVO'::userrole "
+            "WHEN role::text = 'catedratico' THEN 'CATEDRATICO'::userrole "
+            "ELSE role::text END::userrole"
+        ),
+        {
+            "bootstrap_email": os.getenv("BOOTSTRAP_ADMIN_EMAIL", "admin@sistemaslab.dev"),
+            "fallback": _legacy_admin_fallback_role(),
+        },
+    )
+
+    bind.execute(
+        sa.text(
+            "INSERT INTO role_permissions (role_id, permission_id) "
+            "SELECT r.id, p.id FROM roles r CROSS JOIN permissions p "
+            "WHERE r.name IN ('ADMIN', 'DEV') "
+            "ON CONFLICT (role_id, permission_id) DO NOTHING"
+        )
+    )
+    bind.execute(
+        sa.text(
+            "DELETE FROM user_roles WHERE role_id IN "
+            "(SELECT id FROM roles WHERE name IN ('admin','director','coordinador','secretaria','supervisor','catedratico'))"
+        )
+    )
+    assignments = bind.execute(
+        sa.text("SELECT u.id AS user_id, r.id AS role_id FROM users u JOIN roles r ON r.name = u.role::text")
+    ).fetchall()
+    for assignment in assignments:
+        bind.execute(
+            sa.text(
+                "INSERT INTO user_roles (id, user_id, role_id, assigned_at) "
+                "VALUES (:id, :user_id, :role_id, NOW()) "
+                "ON CONFLICT (user_id, role_id) DO NOTHING"
+            ),
+            {"id": str(uuid.uuid4()), "user_id": assignment.user_id, "role_id": assignment.role_id},
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            "UPDATE users SET role = CASE "
+            "WHEN role::text = 'ADMIN' THEN 'admin'::userrole "
+            "WHEN role::text = 'DEV' THEN 'admin'::userrole "
+            "WHEN role::text = 'DECANO' THEN 'admin'::userrole "
+            "WHEN role::text = 'DUEÑO' THEN 'admin'::userrole "
+            "WHEN role::text = 'DIRECTOR' THEN 'director'::userrole "
+            "WHEN role::text = 'ADMINISTRATIVO' THEN 'coordinador'::userrole "
+            "WHEN role::text = 'CATEDRATICO' THEN 'catedratico'::userrole "
+            "ELSE role::text END::userrole"
+        )
+    )
+    bind.execute(
+        sa.text(
+            "DELETE FROM role_permissions WHERE role_id IN "
+            "(SELECT id FROM roles WHERE name IN ('ADMIN', 'DEV'))"
+        )
+    )

--- a/backend/app/api/deps.py
+++ b/backend/app/api/deps.py
@@ -9,11 +9,120 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import get_settings
 from app.core.security import decode_token
 from app.db.session import get_db
-from app.models.user import User, UserRole
+from app.models.user import User, UserRole, canonical_role_from_value
 
 settings = get_settings()
 
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/login")
+
+
+def is_bootstrap_admin(user: User, configured_settings=settings) -> bool:
+    email = getattr(user, "email", None)
+    return bool(email) and email.casefold() == configured_settings.bootstrap_admin_email.casefold()
+
+
+def _canonical_roles_for_user(user: User, configured_settings=settings) -> set[UserRole]:
+    roles: set[UserRole] = set()
+    primary = canonical_role_from_value(
+        getattr(user, "role", None),
+        user_email=getattr(user, "email", None),
+        bootstrap_admin_email=configured_settings.bootstrap_admin_email,
+        legacy_admin_fallback_role=configured_settings.legacy_admin_fallback_role,
+    )
+    if primary:
+        roles.add(primary)
+
+    for assignment in getattr(user, "user_roles", []) or []:
+        role = getattr(assignment, "role", None)
+        if not role or getattr(role, "is_active", True) is False:
+            continue
+        canonical = canonical_role_from_value(
+            getattr(role, "name", None),
+            user_email=getattr(user, "email", None),
+            bootstrap_admin_email=configured_settings.bootstrap_admin_email,
+            legacy_admin_fallback_role=configured_settings.legacy_admin_fallback_role,
+        )
+        if canonical:
+            roles.add(canonical)
+    return roles
+
+
+def has_permission(user: User, code: str, configured_settings=settings) -> bool:
+    roles = _canonical_roles_for_user(user, configured_settings)
+    if not roles:
+        return False
+    if is_bootstrap_admin(user, configured_settings):
+        return True
+
+    for assignment in getattr(user, "user_roles", []) or []:
+        role = getattr(assignment, "role", None)
+        canonical = canonical_role_from_value(
+            getattr(role, "name", None) if role else None,
+            user_email=getattr(user, "email", None),
+            bootstrap_admin_email=configured_settings.bootstrap_admin_email,
+            legacy_admin_fallback_role=configured_settings.legacy_admin_fallback_role,
+        )
+        if not role or canonical not in roles:
+            continue
+        for permission in getattr(role, "permissions", []) or []:
+            if getattr(permission, "code", None) == code:
+                return True
+    return False
+
+
+def _permission_denied() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Not enough permissions",
+    )
+
+
+def ensure_can_assign_role(user: User, target_role: str | UserRole, configured_settings=settings) -> None:
+    canonical = canonical_role_from_value(target_role)
+    if canonical == UserRole.ADMIN:
+        raise _permission_denied()
+    if canonical == UserRole.DEV and not is_bootstrap_admin(user, configured_settings):
+        raise _permission_denied()
+
+
+def assert_object_access(
+    actor: User,
+    *,
+    owner_user_id=None,
+    employee_id=None,
+    configured_settings=settings,
+) -> None:
+    roles = _canonical_roles_for_user(actor, configured_settings)
+    if is_bootstrap_admin(actor, configured_settings) or UserRole.DEV in roles:
+        return
+    if owner_user_id is not None and getattr(actor, "id", None) == owner_user_id:
+        return
+    if employee_id is not None and getattr(actor, "employee_id", None) == employee_id:
+        return
+    raise _permission_denied()
+
+
+def protect_bootstrap_admin_mutation(target_user: User, actor: User, configured_settings=settings) -> None:
+    if is_bootstrap_admin(target_user, configured_settings):
+        raise _permission_denied()
+
+
+def require_permission(code: str):
+    async def dependency(current_user: Annotated[User, Depends(get_current_user)]) -> User:
+        if not has_permission(current_user, code):
+            raise _permission_denied()
+        return current_user
+
+    return dependency
+
+
+def require_any_permission(*codes: str):
+    async def dependency(current_user: Annotated[User, Depends(get_current_user)]) -> User:
+        if not any(has_permission(current_user, code) for code in codes):
+            raise _permission_denied()
+        return current_user
+
+    return dependency
 
 
 async def get_current_user(
@@ -55,11 +164,9 @@ async def get_current_user(
 async def get_current_active_admin(
     current_user: Annotated[User, Depends(get_current_user)],
 ) -> User:
-    if current_user.role != UserRole.admin:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Not enough permissions",
-        )
+    deploy_safe_admin_roles = {UserRole.ADMIN, UserRole.DEV, UserRole.DECANO, UserRole.DUEÑO}
+    if not (_canonical_roles_for_user(current_user) & deploy_safe_admin_roles):
+        raise _permission_denied()
     return current_user
 
 
@@ -67,8 +174,8 @@ async def get_current_coordinador_or_above(
     current_user: Annotated[User, Depends(get_current_user)],
 ) -> User:
     """Allow coordinador, director, admin"""
-    allowed = {UserRole.coordinador, UserRole.director, UserRole.admin}
-    if current_user.role not in allowed:
+    allowed = {UserRole.ADMINISTRATIVO, UserRole.DIRECTOR, UserRole.ADMIN}
+    if not (_canonical_roles_for_user(current_user) & allowed):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Permisos insuficientes")
     return current_user
 
@@ -77,8 +184,8 @@ async def get_current_director_or_above(
     current_user: Annotated[User, Depends(get_current_user)],
 ) -> User:
     """Allow director, admin"""
-    allowed = {UserRole.director, UserRole.admin}
-    if current_user.role not in allowed:
+    allowed = {UserRole.DIRECTOR, UserRole.ADMIN}
+    if not (_canonical_roles_for_user(current_user) & allowed):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Permisos insuficientes")
     return current_user
 
@@ -87,7 +194,7 @@ async def get_current_secretaria_or_above(
     current_user: Annotated[User, Depends(get_current_user)],
 ) -> User:
     """Allow secretaria, coordinador, director, admin"""
-    allowed = {UserRole.secretaria, UserRole.coordinador, UserRole.director, UserRole.admin}
-    if current_user.role not in allowed:
+    allowed = {UserRole.ADMINISTRATIVO, UserRole.DIRECTOR, UserRole.ADMIN}
+    if not (_canonical_roles_for_user(current_user) & allowed):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Permisos insuficientes")
     return current_user

--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -5,7 +5,13 @@ from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import get_db, get_current_user, get_current_active_admin
+from app.api.deps import (
+    ensure_can_assign_role,
+    get_db,
+    get_current_user,
+    get_current_active_admin,
+    settings,
+)
 from app.core.security import (
     create_access_token,
     create_refresh_token,
@@ -82,6 +88,7 @@ async def register(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_admin: Annotated[User, Depends(get_current_active_admin)],
     user_in: UserCreate,
+    configured_settings=settings,
 ) -> User:
     """
     Registrar un nuevo usuario del sistema. Requiere rol admin.
@@ -94,6 +101,14 @@ async def register(
     El email debe ser único y pertenecer al dominio @miumg.edu.gt.
     La contraseña se hashea con bcrypt antes de guardarse.
     """
+    if user_in.email.casefold() == configured_settings.bootstrap_admin_email.casefold():
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Reserved bootstrap admin email cannot be assigned through auth register API",
+        )
+
+    ensure_can_assign_role(current_admin, user_in.role, configured_settings)
+
     result = await db.execute(select(User).where(User.email == user_in.email))
     existing_user = result.scalar_one_or_none()
 

--- a/backend/app/api/v1/endpoints/roles.py
+++ b/backend/app/api/v1/endpoints/roles.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.api.deps import get_db, get_current_active_admin, get_current_user
+from app.api.deps import ensure_can_assign_role, get_db, get_current_active_admin, get_current_user, settings
 from app.models.role import Role
 from app.models.permission import Permission
 from app.models.role_permission import UserRoleAssignment
@@ -64,9 +64,12 @@ async def get_role(
 @router.post("/", response_model=RoleResponse, status_code=status.HTTP_201_CREATED)
 async def create_role(
     db: Annotated[AsyncSession, Depends(get_db)],
-    _: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_active_admin)],
     role_in: RoleCreate,
+    configured_settings=settings,
 ) -> Role:
+    ensure_can_assign_role(current_user, role_in.name, configured_settings)
+
     existing = await db.execute(select(Role).where(Role.name == role_in.name))
     if existing.scalar_one_or_none():
         raise HTTPException(
@@ -91,11 +94,14 @@ async def create_role(
 @router.patch("/{role_id}", response_model=RoleResponse)
 async def update_role(
     db: Annotated[AsyncSession, Depends(get_db)],
-    _: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_active_admin)],
     role_id: UUID,
     role_in: RoleUpdate,
+    configured_settings=settings,
 ) -> Role:
     role = await _get_role_or_404(db, role_id)
+    if role_in.name is not None:
+        ensure_can_assign_role(current_user, role_in.name, configured_settings)
 
     update_data = role_in.model_dump(exclude_unset=True)
     for field, value in update_data.items():
@@ -160,6 +166,7 @@ async def assign_user_roles(
     current_user: Annotated[User, Depends(get_current_active_admin)],
     user_id: UUID,
     payload: UserRoleAssign,
+    configured_settings=settings,
 ) -> list[UserRoleAssignment]:
     # Verify target user exists
     user_result = await db.execute(select(User).where(User.id == user_id))
@@ -176,6 +183,9 @@ async def assign_user_roles(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="One or more role IDs are invalid",
         )
+
+    for role in roles:
+        ensure_can_assign_role(current_user, role.name, configured_settings)
 
     # Business rule: single-role constraint for secretaria/catedratico
     if len(payload.role_ids) > 1:

--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -5,7 +5,13 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.api.deps import get_db, get_current_active_admin
+from app.api.deps import (
+    ensure_can_assign_role,
+    get_db,
+    get_current_active_admin,
+    protect_bootstrap_admin_mutation,
+    settings,
+)
 from app.core.security import get_password_hash
 from app.models.user import User
 from app.schemas.user import UserResponse, UserUpdate, UserPasswordChange
@@ -32,11 +38,30 @@ async def _get_user_or_404(db: AsyncSession, user_id: UUID) -> User:
 )
 async def list_users(
     db: Annotated[AsyncSession, Depends(get_db)],
-    _: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_active_admin)],
+    configured_settings=settings,
 ) -> list[User]:
     """Listar todos los usuarios del sistema. Requiere rol admin."""
     result = await db.execute(select(User).order_by(User.created_at.desc()))
-    return result.scalars().all()
+    return [
+        user
+        for user in result.scalars().all()
+        if not protect_bootstrap_admin_list_item(user, current_user, configured_settings)
+    ]
+
+
+def protect_bootstrap_admin_list_item(user: User, actor: User, configured_settings=settings) -> bool:
+    return user.email.casefold() == configured_settings.bootstrap_admin_email.casefold() and (
+        actor.email.casefold() != configured_settings.bootstrap_admin_email.casefold()
+    )
+
+
+def _ensure_bootstrap_email_is_not_assigned(email: str | None, configured_settings=settings) -> None:
+    if email and email.casefold() == configured_settings.bootstrap_admin_email.casefold():
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Reserved bootstrap admin email cannot be assigned through users API",
+        )
 
 
 @router.patch(
@@ -52,12 +77,19 @@ async def list_users(
 )
 async def update_user(
     db: Annotated[AsyncSession, Depends(get_db)],
-    _: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_active_admin)],
     user_id: UUID,
     user_in: UserUpdate,
+    configured_settings=settings,
 ) -> User:
     """Actualizar nombre, email, rol o estado de un usuario. Requiere rol admin."""
     user = await _get_user_or_404(db, user_id)
+    protect_bootstrap_admin_mutation(user, current_user, configured_settings)
+
+    if user_in.role is not None:
+        ensure_can_assign_role(current_user, user_in.role, configured_settings)
+
+    _ensure_bootstrap_email_is_not_assigned(user_in.email, configured_settings)
 
     # Check email uniqueness if it's being changed
     if user_in.email and user_in.email != user.email:
@@ -92,6 +124,7 @@ async def delete_user(
     db: Annotated[AsyncSession, Depends(get_db)],
     current_user: Annotated[User, Depends(get_current_active_admin)],
     user_id: UUID,
+    configured_settings=settings,
 ) -> None:
     """Eliminar un usuario del sistema. El admin no puede eliminarse a sí mismo. Requiere rol admin."""
     if current_user.id == user_id:
@@ -101,6 +134,7 @@ async def delete_user(
         )
 
     user = await _get_user_or_404(db, user_id)
+    protect_bootstrap_admin_mutation(user, current_user, configured_settings)
     await db.delete(user)
     await db.commit()
 
@@ -117,12 +151,14 @@ async def delete_user(
 )
 async def change_user_password(
     db: Annotated[AsyncSession, Depends(get_db)],
-    _: Annotated[User, Depends(get_current_active_admin)],
+    current_user: Annotated[User, Depends(get_current_active_admin)],
     user_id: UUID,
     payload: UserPasswordChange,
+    configured_settings=settings,
 ) -> None:
     """Cambiar la contraseña de un usuario. Requiere rol admin."""
     user = await _get_user_or_404(db, user_id)
+    protect_bootstrap_admin_mutation(user, current_user, configured_settings)
     user.hashed_password = get_password_hash(payload.new_password)
     user.must_change_password = False
     await db.commit()

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,5 +1,9 @@
 from pydantic_settings import BaseSettings
+from pydantic import field_validator
 from functools import lru_cache
+
+
+LEGACY_ADMIN_FALLBACK_ALLOWED_ROLES = {"DECANO", "DUEÑO", "DIRECTOR", "ADMINISTRATIVO"}
 
 
 class Settings(BaseSettings):
@@ -15,6 +19,20 @@ class Settings(BaseSettings):
     algorithm: str = "HS256"
     access_token_expire_minutes: int = 30
     refresh_token_expire_days: int = 7
+
+    # Bootstrap RBAC admin
+    bootstrap_admin_email: str = "admin@sistemaslab.dev"
+    bootstrap_admin_full_name: str = "System Administrator"
+    bootstrap_admin_password: str = ""
+    legacy_admin_fallback_role: str = "DECANO"
+
+    @field_validator("legacy_admin_fallback_role")
+    @classmethod
+    def validate_legacy_admin_fallback_role(cls, value: str) -> str:
+        normalized = value.strip().upper()
+        if normalized not in LEGACY_ADMIN_FALLBACK_ALLOWED_ROLES:
+            raise ValueError("LEGACY_ADMIN_FALLBACK_ROLE must be a non-system business role")
+        return normalized
 
     # CORS
     cors_origins: str = "http://localhost:4200"

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -10,11 +10,63 @@ from app.db.base import Base
 
 
 class UserRole(str, enum.Enum):
-    admin = "admin"
-    director = "director"
-    coordinador = "coordinador"
-    secretaria = "secretaria"
-    catedratico = "catedratico"
+    ADMIN = "ADMIN"
+    DEV = "DEV"
+    DECANO = "DECANO"
+    DUEÑO = "DUEÑO"
+    DIRECTOR = "DIRECTOR"
+    ADMINISTRATIVO = "ADMINISTRATIVO"
+    CATEDRATICO = "CATEDRATICO"
+    ESTUDIANTE = "ESTUDIANTE"
+    PADRES = "PADRES"
+
+    # Legacy attribute aliases used by existing endpoints/schemas.
+    admin = "ADMIN"
+    director = "DIRECTOR"
+    coordinador = "ADMINISTRATIVO"
+    secretaria = "ADMINISTRATIVO"
+    catedratico = "CATEDRATICO"
+
+
+CANONICAL_ROLE_VALUES = tuple(role.value for role in UserRole)
+
+LEGACY_ROLE_MAPPING = {
+    "admin": "ADMIN",
+    "director": "DIRECTOR",
+    "coordinador": "ADMINISTRATIVO",
+    "secretaria": "ADMINISTRATIVO",
+    "supervisor": "ADMINISTRATIVO",
+    "catedratico": "CATEDRATICO",
+}
+
+
+def canonical_role_from_value(
+    value: str | UserRole | None,
+    *,
+    user_email: str | None = None,
+    bootstrap_admin_email: str | None = None,
+    legacy_admin_fallback_role: str = "DECANO",
+) -> UserRole | None:
+    if value is None:
+        return None
+    if isinstance(value, UserRole):
+        return value
+
+    normalized = str(value).strip()
+    if not normalized:
+        return None
+
+    uppercase = normalized.upper()
+    if uppercase in UserRole._value2member_map_:
+        return UserRole(uppercase)
+
+    legacy = normalized.lower()
+    if legacy == "admin" and user_email and bootstrap_admin_email:
+        if user_email.casefold() != bootstrap_admin_email.casefold():
+            return canonical_role_from_value(legacy_admin_fallback_role)
+
+    mapped = LEGACY_ROLE_MAPPING.get(legacy)
+    return UserRole(mapped) if mapped else None
 
 
 class User(Base):
@@ -29,7 +81,7 @@ class User(Base):
     hashed_password: Mapped[str] = mapped_column(String(255), nullable=False)
     full_name: Mapped[str] = mapped_column(String(200), nullable=True)
     role: Mapped[UserRole] = mapped_column(
-        Enum(UserRole), nullable=False, default=UserRole.admin
+        Enum(UserRole), nullable=False, default=UserRole.ADMIN
     )
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     must_change_password: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)

--- a/backend/create_admin.sql
+++ b/backend/create_admin.sql
@@ -1,31 +1,45 @@
--- SQL script to create admin user directly in PostgreSQL
--- Password: Admin2024! (bcrypt hash)
+-- Repair or create hidden bootstrap ADMIN from psql variables.
+-- Usage:
+--   psql \
+--     -v BOOTSTRAP_ADMIN_EMAIL="$BOOTSTRAP_ADMIN_EMAIL" \
+--     -v BOOTSTRAP_ADMIN_FULL_NAME="$BOOTSTRAP_ADMIN_FULL_NAME" \
+--     -v BOOTSTRAP_ADMIN_PASSWORD_HASH="$BOOTSTRAP_ADMIN_PASSWORD_HASH" \
+--     -f create_admin.sql
 
--- First, check if user exists
-DO $$ 
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM users WHERE email = 'admin@sistemaslab.dev') THEN
-        INSERT INTO users (
-            email,
-            username,
-            password_hash,
-            full_name,
-            role,
-            is_active,
-            created_at,
-            updated_at
-        ) VALUES (
-            'admin@sistemaslab.dev',
-            'admin',
-            '$2b$12$YGqKQ7hC3M.zEhzhHDpDOugFxD5fPqSJvZ0k8nMoKfXJsN9gH.Cfu',  -- bcrypt hash of Admin2024!
-            'System Administrator',
-            'admin',
-            true,
-            NOW(),
-            NOW()
-        );
-        RAISE NOTICE 'Admin user created successfully!';
-    ELSE
-        RAISE NOTICE 'Admin user already exists.';
-    END IF;
-END $$;
+\set ON_ERROR_STOP on
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+INSERT INTO roles (id, name, description, is_active, created_at, updated_at)
+VALUES (uuid_generate_v4(), 'ADMIN', 'Hidden bootstrap system administrator', true, NOW(), NOW())
+ON CONFLICT (name) DO UPDATE
+SET description = EXCLUDED.description,
+    is_active = true,
+    updated_at = NOW();
+
+INSERT INTO users (id, email, hashed_password, full_name, role, is_active, must_change_password, created_at, updated_at)
+VALUES (
+    uuid_generate_v4(),
+    :'BOOTSTRAP_ADMIN_EMAIL',
+    :'BOOTSTRAP_ADMIN_PASSWORD_HASH',
+    :'BOOTSTRAP_ADMIN_FULL_NAME',
+    'ADMIN',
+    true,
+    true,
+    NOW(),
+    NOW()
+)
+ON CONFLICT (email) DO UPDATE
+SET hashed_password = EXCLUDED.hashed_password,
+    full_name = EXCLUDED.full_name,
+    role = 'ADMIN',
+    is_active = true,
+    must_change_password = true,
+    updated_at = NOW();
+
+INSERT INTO user_roles (id, user_id, role_id, assigned_at, assigned_by)
+SELECT uuid_generate_v4(), u.id, r.id, NOW(), u.id
+FROM users u
+JOIN roles r ON r.name = 'ADMIN'
+WHERE u.email = :'BOOTSTRAP_ADMIN_EMAIL'
+ON CONFLICT (user_id, role_id) DO NOTHING;

--- a/backend/create_admin_user.py
+++ b/backend/create_admin_user.py
@@ -1,82 +1,114 @@
 #!/usr/bin/env python3
-"""
-Script to create admin user in the Biometria database.
-Run this directly on the server or through Docker.
-"""
+"""Repair or create the hidden bootstrap ADMIN user from environment settings."""
 
 import asyncio
+import os
 import sys
 from datetime import datetime
-from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
-from sqlalchemy.orm import sessionmaker
+
 from sqlalchemy import select
-import bcrypt
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
 
-# Add the app directory to the path
-sys.path.insert(0, "/app")  # For Docker container
-# sys.path.insert(0, '.')    # For local development
+sys.path.insert(0, "/app")
 
-from app.models.user import User
-from app.db.base import Base
+from app.core.config import Settings, get_settings
+from app.core.security import get_password_hash
+from app.models.role import Role
+from app.models.role_permission import UserRoleAssignment
+from app.models.user import User, UserRole
 
-# Database URL - adjust as needed
-DATABASE_URL = (
-    "postgresql+asyncpg://biometria:biometria_secret@biometria_db:5432/biometria_db"
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql+asyncpg://biometria:biometria_secret@biometria_db:5432/biometria_db",
 )
-# For local testing:
-# DATABASE_URL = "postgresql+asyncpg://richardortiz@localhost:5432/biometria_db"
 
 
-async def create_admin():
-    """Create admin user if it doesn't exist."""
+def build_bootstrap_admin_values(settings: Settings, *, hashed_password: str) -> dict:
+    return {
+        "email": settings.bootstrap_admin_email.casefold(),
+        "hashed_password": hashed_password,
+        "full_name": settings.bootstrap_admin_full_name,
+        "role": UserRole.ADMIN,
+        "is_active": True,
+        "must_change_password": True,
+    }
 
-    # Create engine
+
+def repair_bootstrap_admin_instance(
+    admin: User,
+    settings: Settings,
+    *,
+    hashed_password: str | None = None,
+) -> User:
+    admin.email = settings.bootstrap_admin_email.casefold()
+    admin.full_name = settings.bootstrap_admin_full_name
+    admin.role = UserRole.ADMIN
+    admin.is_active = True
+    admin.must_change_password = True
+    admin.updated_at = datetime.utcnow()
+    if hashed_password:
+        admin.hashed_password = hashed_password
+    return admin
+
+
+async def _ensure_admin_role(session: AsyncSession) -> Role:
+    result = await session.execute(select(Role).where(Role.name == UserRole.ADMIN.value))
+    role = result.scalar_one_or_none()
+    if role:
+        return role
+
+    role = Role(
+        name=UserRole.ADMIN.value,
+        description="Hidden bootstrap system administrator",
+        is_active=True,
+    )
+    session.add(role)
+    await session.flush()
+    return role
+
+
+async def _ensure_admin_assignment(session: AsyncSession, admin: User, role: Role) -> None:
+    result = await session.execute(
+        select(UserRoleAssignment).where(
+            UserRoleAssignment.user_id == admin.id,
+            UserRoleAssignment.role_id == role.id,
+        )
+    )
+    if result.scalar_one_or_none():
+        return
+    session.add(UserRoleAssignment(user_id=admin.id, role_id=role.id, assigned_by=admin.id))
+
+
+async def create_admin() -> None:
+    settings = get_settings()
+    if not settings.bootstrap_admin_password:
+        raise RuntimeError("BOOTSTRAP_ADMIN_PASSWORD is required for bootstrap recovery")
+
+    password_hash = get_password_hash(settings.bootstrap_admin_password)
     engine = create_async_engine(DATABASE_URL, echo=True)
-
-    # Create session
     async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
     async with async_session() as session:
         try:
-            # Check if admin exists
-            result = await session.execute(
-                select(User).where(User.email == "admin@sistemaslab.dev")
-            )
-            existing_admin = result.scalar_one_or_none()
+            email = settings.bootstrap_admin_email.casefold()
+            result = await session.execute(select(User).where(User.email == email))
+            admin = result.scalar_one_or_none()
 
-            if existing_admin:
-                print("❌ Admin user already exists!")
-                print(f"   Email: {existing_admin.email}")
-                print(f"   Role: {existing_admin.role}")
-                return
+            if admin:
+                repair_bootstrap_admin_instance(admin, settings, hashed_password=password_hash)
+                print(f"✅ Bootstrap ADMIN repaired: {email}")
+            else:
+                admin = User(**build_bootstrap_admin_values(settings, hashed_password=password_hash))
+                session.add(admin)
+                await session.flush()
+                print(f"✅ Bootstrap ADMIN created: {email}")
 
-            # Hash the password
-            password = "Admin2024!"  # Change this immediately after first login!
-            password_hash = bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt())
-
-            # Create admin user
-            admin = User(
-                email="admin@sistemaslab.dev",
-                hashed_password=password_hash.decode("utf-8"),
-                full_name="System Administrator",
-                role="admin",
-                is_active=True,
-                created_at=datetime.utcnow(),
-                updated_at=datetime.utcnow(),
-            )
-
-            session.add(admin)
+            role = await _ensure_admin_role(session)
+            await _ensure_admin_assignment(session, admin, role)
             await session.commit()
-
-            print("✅ Admin user created successfully!")
-            print("   Email: admin@sistemaslab.dev")
-            print("   Password: Admin2024!")
-            print(
-                "   ⚠️  IMPORTANT: Change this password immediately after first login!"
-            )
-
-        except Exception as e:
-            print(f"❌ Error creating admin user: {e}")
+        except Exception:
             await session.rollback()
             raise
         finally:

--- a/backend/tests/test_rbac_access_model.py
+++ b/backend/tests/test_rbac_access_model.py
@@ -1,0 +1,683 @@
+from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
+import importlib.util
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.deps import (
+    assert_object_access,
+    ensure_can_assign_role,
+    has_permission,
+    is_bootstrap_admin,
+    get_current_active_admin,
+)
+from app.core.config import Settings
+from app.models.user import CANONICAL_ROLE_VALUES, UserRole, canonical_role_from_value
+from app.schemas.role import RoleCreate, UserRoleAssign
+from app.schemas.user import UserCreate, UserUpdate, UserPasswordChange
+from app.api.v1.endpoints import auth as auth_endpoint
+from app.api.v1.endpoints import roles as roles_endpoint
+from app.api.v1.endpoints import users as users_endpoint
+from create_admin_user import build_bootstrap_admin_values, repair_bootstrap_admin_instance
+
+
+CANONICAL_ROLES = {
+    "ADMIN",
+    "DEV",
+    "DECANO",
+    "DUEÑO",
+    "DIRECTOR",
+    "ADMINISTRATIVO",
+    "CATEDRATICO",
+    "ESTUDIANTE",
+    "PADRES",
+}
+
+
+def _settings(email: str = "root@example.com") -> Settings:
+    return Settings(
+        bootstrap_admin_email=email,
+        bootstrap_admin_full_name="Root Admin",
+        bootstrap_admin_password="ChangeMe123!",
+    )
+
+
+def _user(email: str, role: str | UserRole, **overrides) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=overrides.pop("id", uuid4()),
+        email=email,
+        role=role,
+        employee_id=overrides.pop("employee_id", None),
+        user_roles=overrides.pop("user_roles", []),
+        **overrides,
+    )
+
+
+def _assignment(role_name: str, permission_codes: list[str]) -> SimpleNamespace:
+    permissions = [SimpleNamespace(code=code) for code in permission_codes]
+    role = SimpleNamespace(name=role_name, permissions=permissions, is_active=True)
+    return SimpleNamespace(role=role)
+
+
+def _db_result(value=None, values=None) -> MagicMock:
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = value
+    result.scalars.return_value.all.return_value = values or []
+    return result
+
+
+def _mock_db(*results) -> AsyncMock:
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=list(results))
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    db.delete = AsyncMock()
+    db.add = MagicMock()
+    db.add_all = MagicMock()
+    return db
+
+
+def _load_canonical_migration():
+    migration_path = (
+        Path(__file__).parents[1]
+        / "alembic"
+        / "versions"
+        / "202606101200_canonical_rbac_roles.py"
+    )
+    spec = importlib.util.spec_from_file_location("canonical_rbac_roles", migration_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_user_role_enum_exposes_only_canonical_values_with_legacy_aliases():
+    assert set(CANONICAL_ROLE_VALUES) == CANONICAL_ROLES
+    assert {role.value for role in UserRole} == CANONICAL_ROLES
+    assert UserRole.admin is UserRole.ADMIN
+    assert UserRole.catedratico is UserRole.CATEDRATICO
+
+
+@pytest.mark.parametrize(
+    ("legacy_role", "expected"),
+    [
+        ("admin", UserRole.ADMIN),
+        ("director", UserRole.DIRECTOR),
+        ("coordinador", UserRole.ADMINISTRATIVO),
+        ("secretaria", UserRole.ADMINISTRATIVO),
+        ("supervisor", UserRole.ADMINISTRATIVO),
+        ("catedratico", UserRole.CATEDRATICO),
+    ],
+)
+def test_known_legacy_roles_map_to_canonical_roles(legacy_role, expected):
+    assert canonical_role_from_value(legacy_role) is expected
+
+
+def test_unknown_role_and_missing_permission_fail_closed():
+    actor = _user(
+        "unknown@example.com",
+        "superadmin",
+        user_roles=[_assignment("mystery", ["employees.view"])],
+    )
+
+    assert canonical_role_from_value("superadmin") is None
+    assert has_permission(actor, "employees.view") is False
+
+
+def test_bootstrap_admin_detection_uses_configured_email_case_insensitively():
+    settings = _settings("Root@Example.com")
+
+    assert is_bootstrap_admin(_user("root@example.com", UserRole.ADMIN), settings)
+    assert not is_bootstrap_admin(_user("other@example.com", UserRole.ADMIN), settings)
+
+
+def test_only_bootstrap_admin_can_assign_dev_role():
+    settings = _settings()
+    bootstrap = _user("root@example.com", UserRole.ADMIN)
+    developer = _user("dev@example.com", UserRole.DEV)
+    decano = _user("dean@example.com", UserRole.DECANO)
+
+    ensure_can_assign_role(bootstrap, UserRole.DEV, settings)
+
+    for actor in (developer, decano):
+        with pytest.raises(HTTPException) as exc_info:
+            ensure_can_assign_role(actor, UserRole.DEV, settings)
+        assert exc_info.value.status_code == 403
+
+
+def test_admin_role_is_system_only_and_cannot_be_assigned_through_backoffice():
+    settings = _settings()
+    bootstrap = _user("root@example.com", UserRole.ADMIN)
+    developer = _user("dev@example.com", UserRole.DEV)
+    decano = _user("dean@example.com", UserRole.DECANO)
+
+    for actor in (bootstrap, developer, decano):
+        with pytest.raises(HTTPException) as exc_info:
+            ensure_can_assign_role(actor, UserRole.ADMIN, settings)
+        assert exc_info.value.status_code == 403
+
+
+def test_permission_helper_allows_assigned_permission_and_denies_missing_permission():
+    actor = _user(
+        "director@example.com",
+        UserRole.DIRECTOR,
+        user_roles=[_assignment("DIRECTOR", ["employees.view"])],
+    )
+
+    assert has_permission(actor, "employees.view") is True
+    assert has_permission(actor, "roles.update") is False
+
+
+def test_non_bootstrap_admin_does_not_receive_total_permission_access():
+    settings = _settings("root@example.com")
+    actor = _user("legacy-admin@example.com", UserRole.ADMIN)
+
+    assert has_permission(actor, "roles.manage", settings) is False
+
+
+@pytest.mark.asyncio
+async def test_legacy_business_admin_dependency_remains_deploy_safe():
+    actor = _user("legacy-admin@example.com", UserRole.DECANO)
+
+    assert await get_current_active_admin(actor) is actor
+
+
+def test_object_access_allows_owner_and_denies_unrelated_actor():
+    actor_id = uuid4()
+    actor = _user("student@example.com", UserRole.ESTUDIANTE, id=actor_id)
+
+    assert_object_access(actor, owner_user_id=actor_id)
+
+    with pytest.raises(HTTPException) as exc_info:
+        assert_object_access(actor, owner_user_id=uuid4())
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_users_list_hides_bootstrap_admin_from_backoffice():
+    settings = _settings("root@example.com")
+    bootstrap = _user("root@example.com", UserRole.ADMIN)
+    visible = _user("dean@example.com", UserRole.DECANO)
+    db = _mock_db(_db_result(values=[bootstrap, visible]))
+
+    users = await users_endpoint.list_users(db, visible, settings)
+
+    assert users == [visible]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("payload", "unchanged_field", "unchanged_value"),
+    [
+        (UserUpdate(full_name="Changed"), "full_name", "Root"),
+        (UserUpdate(is_active=False), "is_active", True),
+    ],
+)
+async def test_users_update_denies_bootstrap_admin_mutation_by_non_bootstrap_actor(
+    payload, unchanged_field, unchanged_value
+):
+    settings = _settings("root@example.com")
+    actor = _user("dev@example.com", UserRole.DEV)
+    bootstrap = _user("root@example.com", UserRole.ADMIN, full_name="Root", is_active=True)
+    db = _mock_db(_db_result(value=bootstrap))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await users_endpoint.update_user(
+            db,
+            actor,
+            bootstrap.id,
+            payload,
+            settings,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert getattr(bootstrap, unchanged_field) == unchanged_value
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_users_delete_and_password_change_deny_bootstrap_mutation_by_non_bootstrap_actor():
+    settings = _settings("root@example.com")
+    actor = _user("dev@example.com", UserRole.DEV)
+    bootstrap = _user("root@example.com", UserRole.ADMIN, hashed_password="old-hash")
+
+    delete_db = _mock_db(_db_result(value=bootstrap))
+    with pytest.raises(HTTPException) as delete_exc:
+        await users_endpoint.delete_user(delete_db, actor, bootstrap.id, settings)
+    assert delete_exc.value.status_code == 403
+    delete_db.delete.assert_not_awaited()
+    delete_db.commit.assert_not_awaited()
+
+    password_db = _mock_db(_db_result(value=bootstrap))
+    with pytest.raises(HTTPException) as password_exc:
+        await users_endpoint.change_user_password(
+            password_db,
+            actor,
+            bootstrap.id,
+            UserPasswordChange(new_password="NewPassword123!"),
+            settings,
+        )
+    assert password_exc.value.status_code == 403
+    assert bootstrap.hashed_password == "old-hash"
+    password_db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_users_update_denies_dev_role_assignment_by_non_bootstrap_actor():
+    settings = _settings("root@example.com")
+    actor = _user("dean@example.com", UserRole.DECANO)
+    target = _user("teacher@example.com", UserRole.CATEDRATICO)
+    db = _mock_db(_db_result(value=target))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await users_endpoint.update_user(
+            db,
+            actor,
+            target.id,
+            UserUpdate(role=UserRole.DEV),
+            settings,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert target.role is UserRole.CATEDRATICO
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_users_update_denies_renaming_normal_user_to_reserved_bootstrap_email():
+    settings = _settings("Root@Example.com")
+    actor = _user("dean@example.com", UserRole.DECANO)
+    target = _user("teacher@example.com", UserRole.CATEDRATICO)
+    db = _mock_db(_db_result(value=target), _db_result(value=None))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await users_endpoint.update_user(
+            db,
+            actor,
+            target.id,
+            UserUpdate(email="root@example.com"),
+            settings,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert target.email == "teacher@example.com"
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_users_update_denies_bootstrap_admin_mutation_even_by_bootstrap_actor():
+    settings = _settings("root@example.com")
+    actor = _user("root@example.com", UserRole.ADMIN)
+    bootstrap = _user("root@example.com", UserRole.ADMIN, full_name="Root")
+    db = _mock_db(_db_result(value=bootstrap))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await users_endpoint.update_user(
+            db,
+            actor,
+            bootstrap.id,
+            UserUpdate(full_name="Changed"),
+            settings,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert bootstrap.full_name == "Root"
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auth_register_denies_admin_role_by_non_bootstrap_actor():
+    settings = _settings()
+    actor = _user("dean@example.com", UserRole.DECANO)
+    db = _mock_db(_db_result(value=None))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_endpoint.register(
+            db,
+            actor,
+            UserCreate(
+                email="new-admin@miumg.edu.gt",
+                password="ChangeMe123!",
+                full_name="New Admin",
+                role=UserRole.ADMIN,
+            ),
+            settings,
+        )
+
+    assert exc_info.value.status_code == 403
+    db.add.assert_not_called()
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auth_register_denies_dev_role_by_non_bootstrap_actor():
+    settings = _settings()
+    actor = _user("owner@example.com", UserRole.DUEÑO)
+    db = _mock_db(_db_result(value=None))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_endpoint.register(
+            db,
+            actor,
+            UserCreate(
+                email="new-dev@miumg.edu.gt",
+                password="ChangeMe123!",
+                full_name="New Dev",
+                role=UserRole.DEV,
+            ),
+            settings,
+        )
+
+    assert exc_info.value.status_code == 403
+    db.add.assert_not_called()
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auth_register_allows_bootstrap_actor_to_register_dev():
+    settings = _settings()
+    actor = _user("root@example.com", UserRole.ADMIN)
+    db = _mock_db(_db_result(value=None))
+
+    user = await auth_endpoint.register(
+        db,
+        actor,
+        UserCreate(
+            email="new-dev@miumg.edu.gt",
+            password="ChangeMe123!",
+            full_name="New Dev",
+            role=UserRole.DEV,
+        ),
+        settings,
+    )
+
+    assert user.email == "new-dev@miumg.edu.gt"
+    assert user.role is UserRole.DEV
+    db.add.assert_called_once()
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_auth_register_denies_admin_role_even_by_bootstrap_actor():
+    settings = _settings()
+    actor = _user("root@example.com", UserRole.ADMIN)
+    db = _mock_db(_db_result(value=None))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_endpoint.register(
+            db,
+            actor,
+            UserCreate(
+                email="new-admin@miumg.edu.gt",
+                password="ChangeMe123!",
+                full_name="New Admin",
+                role=UserRole.ADMIN,
+            ),
+            settings,
+        )
+
+    assert exc_info.value.status_code == 403
+    db.add.assert_not_called()
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auth_register_denies_reserved_bootstrap_email_case_insensitively():
+    settings = _settings("root@miumg.edu.gt")
+    actor = _user("root@miumg.edu.gt", UserRole.ADMIN)
+    db = _mock_db(_db_result(value=None))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await auth_endpoint.register(
+            db,
+            actor,
+            UserCreate(
+                email="Root@miumg.edu.gt",
+                password="ChangeMe123!",
+                full_name="Impersonated Root",
+                role=UserRole.DEV,
+            ),
+            settings,
+        )
+
+    assert exc_info.value.status_code == 403
+    db.add.assert_not_called()
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_users_update_denies_admin_role_assignment_by_non_bootstrap_actor():
+    settings = _settings("root@example.com")
+    actor = _user("dean@example.com", UserRole.DECANO)
+    target = _user("teacher@example.com", UserRole.CATEDRATICO)
+    db = _mock_db(_db_result(value=target))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await users_endpoint.update_user(
+            db,
+            actor,
+            target.id,
+            UserUpdate(role=UserRole.ADMIN),
+            settings,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert target.role is UserRole.CATEDRATICO
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_users_update_denies_admin_role_assignment_by_bootstrap_actor():
+    settings = _settings("root@example.com")
+    actor = _user("root@example.com", UserRole.ADMIN)
+    target = _user("teacher@example.com", UserRole.CATEDRATICO)
+    db = _mock_db(_db_result(value=target))
+
+    with pytest.raises(HTTPException) as exc_info:
+        await users_endpoint.update_user(
+            db,
+            actor,
+            target.id,
+            UserUpdate(role=UserRole.ADMIN),
+            settings,
+        )
+
+    assert exc_info.value.status_code == 403
+    assert target.role is UserRole.CATEDRATICO
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_roles_create_dev_is_reserved_to_bootstrap_admin():
+    settings = _settings("root@example.com")
+    actor = _user("dev@example.com", UserRole.DEV)
+    db = _mock_db()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await roles_endpoint.create_role(
+            db,
+            actor,
+            RoleCreate(name="DEV", description="Technical", permission_ids=[]),
+            settings,
+        )
+
+    assert exc_info.value.status_code == 403
+    db.add.assert_not_called()
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_roles_assignment_rejects_dev_replacement_by_non_bootstrap_actor():
+    settings = _settings("root@example.com")
+    actor = _user("dev@example.com", UserRole.DEV)
+    target = _user("teacher@example.com", UserRole.CATEDRATICO)
+    dev_role = SimpleNamespace(id=uuid4(), name="DEV")
+    db = _mock_db(
+        _db_result(value=target),
+        _db_result(values=[dev_role]),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await roles_endpoint.assign_user_roles(
+            db,
+            actor,
+            target.id,
+            UserRoleAssign(role_ids=[dev_role.id]),
+            settings,
+        )
+
+    assert exc_info.value.status_code == 403
+    db.add_all.assert_not_called()
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_roles_assignment_rejects_admin_replacement_by_non_bootstrap_actor():
+    settings = _settings("root@example.com")
+    actor = _user("dev@example.com", UserRole.DEV)
+    target = _user("teacher@example.com", UserRole.CATEDRATICO)
+    admin_role = SimpleNamespace(id=uuid4(), name="ADMIN")
+    assignment = SimpleNamespace(
+        id=uuid4(), user_id=target.id, role_id=admin_role.id, role=admin_role
+    )
+    db = _mock_db(
+        _db_result(value=target),
+        _db_result(values=[admin_role]),
+        _db_result(values=[]),
+        _db_result(values=[assignment]),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await roles_endpoint.assign_user_roles(
+            db,
+            actor,
+            target.id,
+            UserRoleAssign(role_ids=[admin_role.id]),
+            settings,
+        )
+
+    assert exc_info.value.status_code == 403
+    db.add_all.assert_not_called()
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_roles_assignment_rejects_admin_replacement_by_bootstrap_actor():
+    settings = _settings("root@example.com")
+    actor = _user("root@example.com", UserRole.ADMIN)
+    target = _user("teacher@example.com", UserRole.CATEDRATICO)
+    admin_role = SimpleNamespace(id=uuid4(), name="ADMIN")
+    assignment = SimpleNamespace(
+        id=uuid4(), user_id=target.id, role_id=admin_role.id, role=admin_role
+    )
+    db = _mock_db(
+        _db_result(value=target),
+        _db_result(values=[admin_role]),
+        _db_result(values=[]),
+        _db_result(values=[assignment]),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await roles_endpoint.assign_user_roles(
+            db,
+            actor,
+            target.id,
+            UserRoleAssign(role_ids=[admin_role.id]),
+            settings,
+        )
+
+    assert exc_info.value.status_code == 403
+    db.add_all.assert_not_called()
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_roles_assignment_allows_bootstrap_admin_to_assign_dev():
+    settings = _settings("root@example.com")
+    actor = _user("root@example.com", UserRole.ADMIN)
+    target = _user("teacher@example.com", UserRole.CATEDRATICO)
+    dev_role = SimpleNamespace(id=uuid4(), name="DEV")
+    assignment = SimpleNamespace(id=uuid4(), user_id=target.id, role_id=dev_role.id, role=dev_role)
+    db = _mock_db(
+        _db_result(value=target),
+        _db_result(values=[dev_role]),
+        _db_result(values=[]),
+        _db_result(values=[assignment]),
+    )
+
+    assignments = await roles_endpoint.assign_user_roles(
+        db,
+        actor,
+        target.id,
+        UserRoleAssign(role_ids=[dev_role.id]),
+        settings,
+    )
+
+    assert assignments == [assignment]
+    db.add_all.assert_called_once()
+    db.commit.assert_awaited_once()
+
+
+def test_create_admin_values_are_env_driven_and_repair_existing_admin():
+    settings = _settings("root@example.com")
+    values = build_bootstrap_admin_values(settings, hashed_password="hashed")
+
+    assert values["email"] == "root@example.com"
+    assert values["full_name"] == "Root Admin"
+    assert values["role"] is UserRole.ADMIN
+    assert values["hashed_password"] == "hashed"
+    assert values["is_active"] is True
+
+    existing = _user("root@example.com", UserRole.DECANO, is_active=False)
+    repair_bootstrap_admin_instance(existing, settings, hashed_password="new-hash")
+
+    assert existing.role is UserRole.ADMIN
+    assert existing.is_active is True
+    assert existing.hashed_password == "new-hash"
+
+
+def test_create_admin_sql_uses_env_placeholders_not_hardcoded_secret():
+    sql = (Path(__file__).parents[1] / "create_admin.sql").read_text()
+
+    assert "Admin2024!" not in sql
+    assert "BOOTSTRAP_ADMIN_EMAIL" in sql
+    assert "BOOTSTRAP_ADMIN_PASSWORD_HASH" in sql
+    assert "'ADMIN'" in sql
+
+
+def test_canonical_migration_seeds_roles_permissions_and_legacy_mapping():
+    migration = _load_canonical_migration()
+
+    role_names = {role["name"] for role in migration.CANONICAL_ROLES}
+
+    assert role_names == CANONICAL_ROLES
+    assert "users.manage" in {permission[0] for permission in migration.CANONICAL_PERMISSIONS}
+    assert migration.LEGACY_ROLE_MAPPING["coordinador"] == "ADMINISTRATIVO"
+    assert migration.LEGACY_ROLE_MAPPING["catedratico"] == "CATEDRATICO"
+
+
+def test_legacy_admin_fallback_role_rejects_system_or_invalid_values():
+    assert _settings().legacy_admin_fallback_role == "DECANO"
+
+    for fallback in ("ADMIN", "DEV", "superadmin"):
+        with pytest.raises(ValueError):
+            Settings(
+                bootstrap_admin_email="root@example.com",
+                bootstrap_admin_full_name="Root Admin",
+                bootstrap_admin_password="ChangeMe123!",
+                legacy_admin_fallback_role=fallback,
+            )
+
+
+def test_canonical_migration_downgrade_restores_legacy_role_values_without_deleting_assignments():
+    migration = _load_canonical_migration()
+    downgrade_source = inspect.getsource(migration.downgrade)
+
+    assert "WHEN role::text = 'ADMIN' THEN 'admin'::userrole" in downgrade_source
+    assert "WHEN role::text = 'DECANO' THEN 'admin'::userrole" in downgrade_source
+    assert "DELETE FROM user_roles" not in downgrade_source
+    assert "DELETE FROM roles" not in downgrade_source

--- a/openspec/changes/fix-rbac-users-access-model/tasks.md
+++ b/openspec/changes/fix-rbac-users-access-model/tasks.md
@@ -27,10 +27,21 @@ Chain strategy: feature-branch-chain
 
 ## Phase 1: Foundation / Migration
 
-- [ ] 1.1 RED: add canonical role, unknown-role denial, and bootstrap detection tests in `backend/tests/test_rbac_access_model.py`.
-- [ ] 1.2 GREEN: update `backend/app/core/config.py`, `backend/app/models/user.py`, and `backend/alembic/versions/*_canonical_rbac_roles.py`.
-- [ ] 1.3 RED/GREEN: test/update `backend/create_admin_user.py` and `backend/create_admin.sql` for env bootstrap repair.
-- [ ] 1.4 RED/GREEN: test/add permission and object-access helpers in `backend/app/api/deps.py`.
+- [x] 1.1 RED: add canonical role, unknown-role denial, and bootstrap detection tests in `backend/tests/test_rbac_access_model.py`.
+- [x] 1.2 GREEN: update `backend/app/core/config.py`, `backend/app/models/user.py`, and `backend/alembic/versions/*_canonical_rbac_roles.py`.
+- [x] 1.3 RED/GREEN: test/update `backend/create_admin_user.py` and `backend/create_admin.sql` for env bootstrap repair.
+- [x] 1.4 RED/GREEN: test/add permission and object-access helpers in `backend/app/api/deps.py`.
+
+## PR1 Foundation Blocker Fixes
+
+- [x] B1 RED/GREEN: enforce `protect_bootstrap_admin_mutation()` in users endpoints for update, deactivate via `is_active`, delete, and password change.
+- [x] B2 RED/GREEN: enforce `ensure_can_assign_role()` in users and roles endpoints so only bootstrap `ADMIN` can create, assign, or replace `DEV`.
+- [x] B3 RED/GREEN: preserve deploy-safe access for migrated business admins while avoiding total `has_permission()` access for non-bootstrap `ADMIN`.
+- [x] B4 RED/GREEN: validate `LEGACY_ADMIN_FALLBACK_ROLE` against a non-system business-role allowlist.
+- [x] B5 RED/GREEN: make Alembic downgrade map canonical user roles back to legacy values without deleting role assignments or canonical role rows.
+- [x] B6 RED/GREEN: make `ADMIN` system-only by blocking `ADMIN` assignment through users and RBAC role assignment backoffice paths, including bootstrap actors.
+- [x] B7 RED/GREEN: reserve the configured bootstrap admin email from users API reassignment paths case-insensitively and keep bootstrap admin mutation server-side only.
+- [x] B8 RED/GREEN: enforce `ensure_can_assign_role()` and reserved bootstrap email protection in `/auth/register` so business admins cannot create `ADMIN` or `DEV` users.
 
 ## Phase 2: Users / RBAC APIs
 

--- a/openspec/changes/fix-rbac-users-access-model/verify-pr1-report.md
+++ b/openspec/changes/fix-rbac-users-access-model/verify-pr1-report.md
@@ -1,0 +1,130 @@
+## Verification Report
+
+**Change**: `fix-rbac-users-access-model`
+**Slice**: PR1 foundation only, after blocker fixes B1-B8
+**Branch**: `fix/rbac-users-access-model-foundation`
+**Verdict**: PASS WITH WARNINGS
+**Session**: `verify-fix-rbac-users-access-model-pr1-post-blockers`
+
+### Scope Verified
+
+- Canonical role enum/model compatibility and legacy role mapping foundation.
+- Hidden bootstrap `ADMIN` configuration, list filtering, and mutation protection.
+- Bootstrap admin create/repair script and SQL artifact.
+- System role assignment restrictions in users, roles, and auth register endpoint paths touched by PR1 blockers (`ADMIN` system-only; `DEV` bootstrap-only).
+- Reserved bootstrap admin email cannot be assigned through users API update paths or created through `/auth/register`, and bootstrap admin mutation remains server-side only.
+- Fallback role validation for non-bootstrap legacy admins.
+- Non-bootstrap `ADMIN` permission narrowing while keeping deploy-safe business admin access.
+- Alembic migration source/compile behavior, including downgrade safety source checks.
+- Backend foundation and blocker regression tests.
+
+### SDD Artifact Review
+
+- Read `proposal.md`, `design.md`, `tasks.md`, all specs under `specs/**`, and this verify report.
+- No apply-progress file exists under `openspec/changes/fix-rbac-users-access-model`; prior apply-progress was found in Engram topic `sdd/fix-rbac-users-access-model/apply-progress`.
+- PR1 aligns with Phase 1 and PR1 Foundation Blocker Fixes in `tasks.md`.
+- Phase 2 users/RBAC API completion, Phase 3 permission-request/attendance enforcement, Phase 4 Angular visibility, and Phase 5 cleanup remain intentionally incomplete.
+
+### Completeness
+
+| Metric | Value |
+|--------|-------|
+| Tasks total | 22 |
+| Tasks complete | 12 |
+| Tasks incomplete | 10 |
+
+Incomplete tasks are outside the PR1 foundation boundary: Phase 2, Phase 3, Phase 4, and Phase 5 tasks remain open.
+
+### Correctness: Specs
+
+| Requirement | PR1 Status | Notes |
+|-------------|------------|-------|
+| Canonical Roles | Implemented for PR1 | `UserRole`, migration constants, and tests cover canonical roles and legacy aliases. |
+| Hidden Bootstrap Admin | Implemented for PR1 | List hiding, update/deactivate/delete/password-change denial, and recovery helpers are covered. |
+| DEV Role Assignment Restriction | Implemented for PR1 | Users update, auth register, roles create, and roles assignment paths call `ensure_can_assign_role()`; `ADMIN` is also blocked as a system-only role through backoffice/API paths. |
+| DEV Technical Administration | Partial by design | PR1 covers foundation and DEV assignment boundaries; full RBAC internals remain Phase 2. |
+| Business Top Role Boundaries | Partial by design | Deploy-safe business admin dependency remains; full RBAC/audit denial coverage remains Phase 2/3. |
+| Module Access Boundaries | Partial by design | Foundation helpers exist; endpoint-wide module/object enforcement remains Phase 2/3. |
+| Users View Role Assignment | Partial by design | Backend role assignment foundation exists; full Users view/API separation remains Phase 2/4. |
+| Roles View Permission Configuration | Partial by design | Roles endpoint guard coverage exists for DEV replacement; full permission matrix separation remains Phase 2. |
+| Backend Authorization Enforcement | Partial by design | PR1 blockers are covered; full protected endpoint enforcement remains later phases. |
+| Legacy Role Migration Compatibility | Implemented for PR1 | Upgrade mapping, fallback validation, and downgrade source safety are covered. |
+| Authorization Test Coverage | Implemented for PR1 boundary | `backend/tests/test_rbac_access_model.py` has 39 foundation/blocker tests. |
+| Permission Request Workflow specs | Not in PR1 | Explicitly deferred to Phase 3. |
+| Attendance Access Control specs | Not in PR1 | Explicitly deferred to Phase 3. |
+
+### Blocker Verification
+
+| Blocker | Status | Evidence |
+|---------|--------|----------|
+| B1 bootstrap admin mutation protection | Fixed | `users.py` calls `protect_bootstrap_admin_mutation()` for update, delete, and password change; tests cover list hiding, profile update, deactivation via `is_active`, delete, and password change denial. |
+| B2 DEV assignment enforcement | Fixed | `users.py` and `roles.py` call `ensure_can_assign_role()`; tests cover user role update denial, role create denial, role replacement denial, and bootstrap allow. |
+| B3 deploy-safe admins without total non-bootstrap ADMIN access | Fixed | `has_permission()` only grants total access to bootstrap admin; `get_current_active_admin()` allows deploy-safe business roles; tests cover both. |
+| B4 fallback role validation | Fixed | `Settings` and migration fallback validator reject `ADMIN`, `DEV`, and unknown values; tests cover defaults and invalid values. |
+| B5 downgrade safety | Fixed with environment limitation | Downgrade source maps canonical `users.role` values back to legacy values and does not delete `user_roles` or canonical `roles`; migration compiles. Live DB execution was not verified. |
+| B6 ADMIN system-only assignment guard | Fixed | `ensure_can_assign_role()` rejects `ADMIN` for all backoffice assignment paths; tests cover non-bootstrap and bootstrap users update attempts plus RBAC role assignment attempts. |
+| B7 reserved bootstrap email reassignment guard | Fixed | Users update now rejects assigning the configured bootstrap email case-insensitively and blocks bootstrap admin API mutation even by bootstrap actors; server-side recovery remains covered by `repair_bootstrap_admin_instance()`. |
+| B8 auth register assignment guard | Fixed | `/auth/register` now rejects reserved bootstrap email creation, calls `ensure_can_assign_role()`, denies `ADMIN` for all actors, denies `DEV` for non-bootstrap actors, and still allows bootstrap `ADMIN` to register `DEV`. |
+
+### Coherence: Design
+
+| Decision | Followed? | Notes |
+|----------|-----------|-------|
+| DB-backed permissions are canonical | Partial | Foundation helpers and seed permissions exist; full endpoint replacement is intentionally later. |
+| Env-backed hidden bootstrap admin | Yes | Config, helper checks, recovery script, SQL, users endpoint protections, and tests align. |
+| UI authorization consumes backend permissions | Not in PR1 | No frontend files changed; Angular work remains Phase 4. |
+| Reversible migration | Partial | Migration source compiles and downgrade source maps roles safely; live DB upgrade/downgrade was not executed. |
+
+### Testing
+
+| Area | Tests Exist? | Coverage |
+|------|--------------|----------|
+| Canonical roles and legacy mapping | Yes | Good for PR1. |
+| Bootstrap admin detection/list/mutation protection | Yes | Good for PR1, including reserved-email reassignment and API mutation denial. |
+| System role assignment restrictions | Yes | Good for PR1: `DEV` bootstrap-only; `ADMIN` system-only and blocked through backoffice/API paths including `/auth/register`. |
+| Non-bootstrap ADMIN total-access prevention | Yes | Good for PR1. |
+| Fallback role validation | Yes | Good for PR1. |
+| Migration downgrade source safety | Yes | Source-level only; not live DB execution. |
+| Permission request endpoints | No | Deferred to Phase 3. |
+| Attendance role/object endpoint enforcement | No | Deferred to Phase 3. |
+| Frontend permission visibility | No | Deferred to Phase 4; no frontend diff in PR1. |
+
+### Commands Run
+
+| Command | Result |
+|---------|--------|
+| `pytest` from `backend/` | Failed: `zsh:1: command not found: pytest` |
+| `PYTHONPATH=. ./.venv/bin/pytest tests/test_rbac_access_model.py -k "reserved_bootstrap_email or bootstrap_admin_mutation_even_by_bootstrap_actor"` from `backend/` before implementation | Failed as expected: 2 failed with `DID NOT RAISE` |
+| `PYTHONPATH=. ./.venv/bin/pytest tests/test_rbac_access_model.py -k "reserved_bootstrap_email or bootstrap_admin_mutation_even_by_bootstrap_actor"` from `backend/` after implementation | Passed: 2 passed, 32 deselected, 8 warnings |
+| `PYTHONPATH=. ./.venv/bin/pytest tests/test_rbac_access_model.py` from `backend/` | Passed: 34 passed, 9 warnings |
+| `PYTHONPATH=. ./.venv/bin/pytest tests/test_rbac_access_model.py -k auth_register` from `backend/` before implementation | Failed as expected: 4 failed with `DID NOT RAISE`, 1 passed, 34 deselected, 8 warnings |
+| `PYTHONPATH=. ./.venv/bin/pytest tests/test_rbac_access_model.py -k auth_register` from `backend/` after implementation | Passed: 5 passed, 34 deselected, 8 warnings |
+| `PYTHONPATH=. ./.venv/bin/pytest tests/test_rbac_access_model.py` from `backend/` after B8 | Passed: 39 passed, 9 warnings |
+| `PYTHONPATH=. ./.venv/bin/pytest` from `backend/` after B8 | Passed: 79 passed, 33 warnings |
+| `PYTHONPATH=. ./.venv/bin/python -m py_compile alembic/versions/202606101200_canonical_rbac_roles.py` from `backend/` | Passed: no output |
+| `PYTHONPATH=. ./.venv/bin/alembic heads` from `backend/` | Passed: `202606101200 (head)` |
+| `PYTHONPATH=. ./.venv/bin/alembic current` from `backend/` | Failed due local environment: `ValueError: the greenlet library is required to use this function. No module named 'greenlet'` |
+
+### Frontend Verification
+
+Skipped. Git status/diff show no frontend file changes; PR1 is backend/OpenSpec only and Angular permission visibility is explicitly deferred to Phase 4 / PR4. The project rule says to run frontend tests, but the orchestrator constraint allows skipping when no frontend changed.
+
+### Issues Found
+
+**CRITICAL**: None for PR1 foundation/blocker scope.
+
+**WARNING**:
+
+- Live Alembic upgrade/downgrade/current execution was not verified because local Alembic DB access fails before connection with missing `greenlet`.
+- Existing backend suite emits 33 warnings, mostly Pydantic V2 class-based config deprecations and `datetime.utcnow()` deprecations.
+- Full OpenSpec capability remains incomplete outside PR1: Phase 2, Phase 3, and Phase 4 are still open.
+
+**SUGGESTION**:
+
+- Before archive or deploy, run Alembic upgrade/downgrade against a real PostgreSQL database in an environment with `greenlet` installed.
+
+### Verdict
+
+PASS WITH WARNINGS for PR1 foundation after blocker fixes B1-B8.
+
+PR1 blocker fixes are verified by source inspection and passing backend tests. Remaining warnings are environment/test-debt limitations or later-phase scope, not PR1 blocker failures.


### PR DESCRIPTION
## Summary

Adds PR1 foundation for the RBAC/Users access model chain.

Related issue: #29
Depends on tracker: #30

## Chain Context

```text
main
└── tracker: fix/rbac-users-access-model (#30, draft/no-merge)
    └── 📍 PR1 foundation: fix/rbac-users-access-model-foundation
    └── PR2 users/roles enforcement (pending)
    └── PR3 module access enforcement (pending)
    └── PR4 frontend visibility (pending)
```

## Scope
- Canonical RBAC role enum and legacy mapping foundation.
- Env-driven hidden bootstrap ADMIN configuration.
- Bootstrap admin server-side create/repair script + SQL updates.
- Foundation guards for ADMIN/DEV assignment, reserved bootstrap email, and bootstrap mutation protection.
- Canonical RBAC Alembic migration foundation.
- Backend tests for protected foundation paths.

## Out of Scope
- Full frontend route/sidebar/card visibility conversion.
- Full module-by-module permission enforcement.
- Padres/children/calificaciones feature work.

## Verification
- `PYTHONPATH=. ./.venv/bin/pytest tests/test_rbac_access_model.py` → 39 passed, 9 warnings.
- `PYTHONPATH=. ./.venv/bin/pytest` → 79 passed, 33 warnings.
- `PYTHONPATH=. ./.venv/bin/python -m py_compile alembic/versions/202606101200_canonical_rbac_roles.py` → passed.
- `PYTHONPATH=. ./.venv/bin/alembic heads` → `202606101200 (head)`.
- `git diff --check` → OK.

## Known Limitations
- Live Alembic upgrade/downgrade against PostgreSQL was not run locally due environment limitation (`greenlet`).
- Existing warning debt remains (Pydantic/datetime deprecations).

## Review Budget
This PR is intentionally chain-only and exceeds the 400-line target due migration + security tests; subsequent slices must remain narrower.